### PR TITLE
DM-49202: Add initial version of stage_chunk function

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2025 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# PPDB Cloud Functions
+
+This repository contains [Google Cloud Run](https://cloud.google.com/functions) functions for the Rubin Observatory's Prompt Products Database (PPDB) along with related scripts and configuration files.
+
+There is currently a single function for triggering a [Dataflow](https://cloud.google.com/products/dataflow) job which loads table data into BigQuery from Parquet files in Google Cloud Storage (GCS). The implementation of this function is contained in the [stage_chunk](./stage_chunk) directory with the following files:
+
+- `build-container.sh` - Builds the Docker container for the Dataflow job
+- `build-flex-template.sh` - Deploys the [flex template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates) for the Dataflow job
+- `deploy-function.sh` - Deploys the Cloud Function to listen for events on the `stage-chunk-topic` Pub/Sub topic
+- `Dockerfile` - Dockerfile for the Dataflow job which launches the [Apache Beam](https://beam.apache.org/) script
+- `main.py` - Implementation of the Cloud Function which triggers the Dataflow job. The function accepts the name of a GCS bucket and prefix containing the Parquet files for a replica chunk, e.g., `gs://rubin-ppdb-test-bucket-1/data/tmp/2025/04/23/1737056400`.
+- `Makefile` - Makefile with helpful targets for deploying and tearing down the Cloud Function. Typing `make` will print all available targets.
+- `metadata.json` - Required metadata for the Dataflow job
+- `requirements.txt` - Python dependencies for the Dataflow job
+- `stage_chunk_beam_job.py` - [Apache Beam](https://beam.apache.org/) script for loading the data into BigQuery from Parquet files in GCS.
+- `teardown.sh` - Script to teardown the Cloud Function and Dataflow configuration, including deleting the Docker image, removing the flex template, etc.

--- a/stage_chunk/Dockerfile
+++ b/stage_chunk/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/dataflow-templates-base/python3-template-launcher-base:latest
+
+# Copy your pipeline code inside the container
+WORKDIR /dataflow/template
+COPY stage_chunk_beam_job.py .
+
+# Install dependencies
+RUN pip install --no-cache-dir google-cloud-storage
+
+# Set required environment variable for Flex Templates
+ENV FLEX_TEMPLATE_PYTHON_PY_FILE=stage_chunk_beam_job.py
+
+# Use the standard launcher ENTRYPOINT
+ENTRYPOINT ["/opt/apache/beam/boot"]

--- a/stage_chunk/Makefile
+++ b/stage_chunk/Makefile
@@ -1,0 +1,34 @@
+help:
+	@echo "Usage:"
+	@echo "  make container         Build and push the container to GCR"
+	@echo "  make flex-template     Build the Flex template"
+	@echo "  make function          Deploy the function"
+	@echo "  make deploy            Redeploy the container, function, and Flex template"
+	@echo "  make teardown          Tear down the function"
+	@echo "  make logs              Show the last 50 logs for the function"
+	@echo "  make help              Show this help message"
+
+container:
+	@echo "Building container..."
+	./build-container.sh
+	@echo "Done building container."
+
+flex-template:
+	@echo "Building flex template..."
+	./build-flex-template.sh
+	@echo "Done building Flex template."
+
+function:
+	@echo "Deploying function..."
+	./deploy-function.sh
+	@echo "Done deploying function."
+
+deploy: container flex-template function
+
+teardown:
+	@echo "Tearing down function..."
+	./teardown.sh
+	@echo "Done tearing down function."
+
+logs:
+	gcloud functions logs read trigger_stage_chunk --region=us-central1 --limit=50 | less

--- a/stage_chunk/build-container.sh
+++ b/stage_chunk/build-container.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS is unset or empty. Please set it to your service account key file."
+  exit 1
+fi
+
+if [ -z "${GCP_PROJECT:-}" ]; then
+  echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
+  exit 1
+fi
+
+gcloud builds submit --tag "gcr.io/${GCP_PROJECT}/stage-chunk-image" .

--- a/stage_chunk/build-flex-template.sh
+++ b/stage_chunk/build-flex-template.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS is unset or empty. Please set it to your service account key file."
+  exit 1
+fi
+
+if [ -z "${GCP_PROJECT:-}" ]; then
+  echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
+  exit 1
+fi
+
+if [ -z "${GCS_BUCKET:-}" ]; then
+  echo "GCS_BUCKET is unset or empty. Please set it to your Google Cloud Storage bucket name."
+  exit 1
+fi
+
+echo "Creating Dataflow Flex Template..."
+gcloud dataflow flex-template build "gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json" \
+  --image "gcr.io/${GCP_PROJECT}/stage-chunk-image" \
+  --sdk-language "PYTHON" \
+  --metadata-file "metadata.json"
+
+echo "Flex Template created and pushed to gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json"

--- a/stage_chunk/deploy-function.sh
+++ b/stage_chunk/deploy-function.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS is unset or empty. Please set it to your service account key file."
+  exit 1
+fi
+
+if [ -z "${GCP_PROJECT:-}" ]; then
+  echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
+  exit 1
+fi
+
+if [ -z "${REGION:-}" ]; then
+  echo "REGION is unset or empty. Please set it to your Google Cloud region."
+  exit 1
+fi
+
+if [ -z "${DATAFLOW_TEMPLATE_PATH:-}" ]; then
+  echo "DATAFLOW_TEMPLATE_PATH is unset or empty. Please set it to your Dataflow template path."
+  exit 1
+fi
+
+if [ -z "${SERVICE_ACCOUNT_EMAIL:-}" ]; then
+  echo "SERVICE_ACCOUNT_EMAIL is unset or empty. Please set it to your Google Cloud service account email."
+  exit 1
+fi
+
+if [ -z "${DATASET_ID:-}" ]; then
+  echo "DATASET_ID is unset or empty. Please set it to your Google Cloud dataset ID."
+  exit 1
+fi
+
+if [ -z "${TEMP_LOCATION:-}" ]; then
+  echo "TEMP_LOCATION is unset or empty. Please set it to your Google Cloud temporary location."
+  exit 1
+fi
+
+# Deploy the Cloud Function
+gcloud functions deploy trigger_stage_chunk \
+  --runtime=python311 \
+  --region=${REGION} \
+  --source=. \
+  --entry-point=trigger_stage_chunk \
+  --service-account=${SERVICE_ACCOUNT_EMAIL} \
+  --trigger-topic=stage-chunk-topic \
+  --set-env-vars "PROJECT_ID=${GCP_PROJECT},REGION=${REGION},SERVICE_ACCOUNT_EMAIL=${SERVICE_ACCOUNT_EMAIL},DATASET_ID=${DATASET_ID},TEMP_LOCATION=${TEMP_LOCATION},DATAFLOW_TEMPLATE_PATH=${DATAFLOW_TEMPLATE_PATH}" \
+  --gen2

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -66,7 +66,6 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
         The dictionary with data specific to this type of event. The `data`
         field contains a base64-encoded string representing a JSON message
         with `bucket` and `name` fields.
-
     context : `google.cloud.functions.Context`
         Metadata of triggering event including `event_id`.
     """

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -1,0 +1,145 @@
+# This file is part of ppdb-cloud-functions
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import base64
+import json
+import logging
+import os
+import posixpath
+from datetime import datetime, timezone
+from typing import Any
+
+import google.auth
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud.functions_v1.context import Context
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+logging.basicConfig(level=logging.INFO)
+
+
+# Helper function to require environment variables
+def require_env(var_name: str) -> str:
+    """Require an environment variable to be set."""
+    value = os.getenv(var_name)
+    if not value:
+        raise LookupError(f"Missing required environment variable: {var_name}")
+    return value
+
+
+# Read required environment variables
+PROJECT_ID = require_env("PROJECT_ID")
+DATAFLOW_TEMPLATE_PATH = require_env("DATAFLOW_TEMPLATE_PATH")
+REGION = require_env("REGION")
+SERVICE_ACCOUNT_EMAIL = require_env("SERVICE_ACCOUNT_EMAIL")
+DATASET_ID = require_env("DATASET_ID")
+TEMP_LOCATION = require_env("TEMP_LOCATION")
+
+_credentials, _ = google.auth.default()
+_dataflow_client = build("dataflow", "v1b3", credentials=_credentials)
+
+
+def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
+    """Cloud Function to launch a Dataflow job to stage PPDB data.
+
+    Parameters
+    ----------
+    event : `dict`
+        The dictionary with data specific to this type of event. The `data`
+        field contains a base64-encoded string representing a JSON message
+        with `bucket` and `name` fields.
+
+    context : `google.cloud.functions.Context`
+        Metadata of triggering event including `event_id`.
+    """
+    try:
+        message = base64.b64decode(event["data"]).decode("utf-8")
+    except Exception:
+        logging.exception("Malformed or missing Pub/Sub data payload")
+        return
+
+    try:
+        data = json.loads(message)
+    except json.JSONDecodeError:
+        logging.exception("Failed to decode JSON from Pub/Sub message")
+        return
+
+    try:
+        bucket = data["bucket"]
+        name = data["name"]
+    except KeyError:
+        logging.exception("Missing required key in Pub/Sub message")
+        return
+
+    input_path = f"gs://{bucket}/{name}"
+    chunk_id = posixpath.basename(name)
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+    job_name = f"stage-chunk-{chunk_id}-{timestamp}"
+
+    launch_body = {
+        "launchParameter": {
+            "jobName": job_name,
+            "containerSpecGcsPath": DATAFLOW_TEMPLATE_PATH,
+            "parameters": {"input_path": input_path, "dataset_id": DATASET_ID},
+            "environment": {
+                "serviceAccountEmail": SERVICE_ACCOUNT_EMAIL,
+                "tempLocation": TEMP_LOCATION,
+            },
+        }
+    }
+
+    logging.info("Launching Dataflow job %s for input path %s", job_name, input_path)
+    logging.info("Triggered by event ID: %s", context.event_id)
+    logging.info("Dataflow launch body: %s", json.dumps(launch_body))
+
+    try:
+        request = (
+            _dataflow_client.projects()
+            .locations()
+            .flexTemplates()
+            .launch(projectId=PROJECT_ID, location=REGION, body=launch_body)
+        )
+        response = request.execute()
+
+        if "job" not in response:
+            logging.error("Dataflow API response missing 'job' field: %s", response)
+            return
+
+        job_id = response.get("job", {}).get("id", "unknown")
+        logging.info(f"Dataflow job launched: {job_id}")
+
+    except HttpError as e:
+        if e.resp.status in [429, 500, 503]:
+            logging.warning("Retryable HTTP error (%s): %s", e.resp.status, e)
+            raise  # Will trigger retry
+        else:
+            logging.error("Non-retryable HTTP error: %s", e)
+            return  # Acknowledge message
+
+    except GoogleAPICallError:
+        logging.exception("Retryable GCP API error")
+        raise  # Will trigger retry
+
+    except Exception:
+        logging.exception("Unexpected error during job submission")
+        return  # Acknowledge message
+
+    return

--- a/stage_chunk/metadata.json
+++ b/stage_chunk/metadata.json
@@ -1,0 +1,20 @@
+{
+    "name": "Stage Chunk Beam Job",
+    "description": "Loads parquet chunks into BigQuery",
+    "parameters": [
+      {
+        "name": "input_path",
+        "label": "GCS input path",
+        "helpText": "Path to directory containing Parquet files",
+        "paramType": "TEXT",
+        "isOptional": false
+      },
+      {
+        "name": "dataset_id",
+        "label": "BigQuery dataset ID",
+        "helpText": "BigQuery dataset to load into",
+        "paramType": "TEXT",
+        "isOptional": false
+      }
+    ]
+  }

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework
+google-auth
+google-api-python-client

--- a/stage_chunk/stage_chunk_beam_job.py
+++ b/stage_chunk/stage_chunk_beam_job.py
@@ -1,0 +1,216 @@
+# This file is part of ppdb-cloud-functions
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+import json
+import logging
+from typing import Optional
+from urllib.parse import urlparse
+
+import apache_beam
+from apache_beam import PCollection
+from apache_beam.io.gcp.bigquery import BigQueryDisposition, WriteToBigQuery
+from apache_beam.io.parquetio import ReadFromParquet
+from apache_beam.options.pipeline_options import GoogleCloudOptions, PipelineOptions, SetupOptions
+from google.cloud import storage
+
+logging.basicConfig(level=logging.INFO)
+
+
+class BeamSuppressUpdateDestinationSchemaWarning(logging.Filter):
+    """Suppresses the UpdateDestinationSchema warning from Apache Beam."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Suppress the UpdateDestinationSchema warning.
+
+        Parameters
+        ----------
+        record : `logging.LogRecord`
+            The log record to filter.
+        """
+        if record.name == "apache_beam.transforms.core":
+            message = str(record.getMessage())
+            if "No iterator is returned by the process method" in message:
+                return False
+        return True
+
+
+logging.getLogger("apache_beam.transforms.core").addFilter(BeamSuppressUpdateDestinationSchemaWarning())
+
+
+class CustomOptions(PipelineOptions):
+    """Custom options for the pipeline."""
+
+    @classmethod
+    def _add_argparse_args(cls, parser: argparse.ArgumentParser) -> None:
+        """Add custom arguments to the parser.
+
+        Parameters
+        ----------
+        parser : `argparse.ArgumentParser`
+            The argument parser to add arguments to.
+        """
+        parser.add_argument("--dataset_id", required=True, help="BigQuery dataset ID")
+        parser.add_argument(
+            "--input_path", required=True, help="GCS path to directory containing Parquet files"
+        )
+
+
+def read_parquet(pipeline: apache_beam.Pipeline, input_path: str, name: str) -> PCollection:
+    """Read Parquet files from GCS.
+
+    Parameters
+    ----------
+    pipeline : `apache_beam.Pipeline`
+        The Apache Beam pipeline.
+    input_path : `str`
+        The GCS path to the directory containing Parquet files.
+    name : `str`
+        The name of the Parquet file to read (without extension).
+
+    Returns
+    -------
+    transform: `apache_beam.PTransform`
+        The transform to read the Parquet file.
+    """
+    return pipeline | f"Read{name}" >> ReadFromParquet(f"{input_path}/{name}")
+
+
+def write_to_bigquery(
+    pcoll: apache_beam.PCollection, project_id: str, dataset_id: str, table_name: str, temp_location: str
+) -> PCollection:
+    """Write PCollection to BigQuery.
+
+    Parameters
+    ----------
+    pcoll : `apache_beam.PCollection`
+        The PCollection to write to BigQuery.
+    project_id : `str`
+        The GCP project ID.
+    dataset_id : `str`
+        The BigQuery dataset ID.
+    table_name : `str`
+        The name of the BigQuery table.
+    temp_location : `str`
+        The GCS path for temporary files.
+
+    Returns
+    -------
+    transform: `apache_beam.PTransform`
+        The transform to write the PCollection to BigQuery.
+    """
+    return pcoll | f"Write{table_name}" >> WriteToBigQuery(
+        table=f"{project_id}:{dataset_id}.{table_name}",
+        create_disposition=BigQueryDisposition.CREATE_NEVER,
+        write_disposition=BigQueryDisposition.WRITE_APPEND,
+        custom_gcs_temp_location=temp_location,
+    )
+
+
+def parse_input_path(input_path: str) -> tuple[str, str]:
+    """Parse the input URL to extract the bucket name and object path.
+
+    Parameters
+    ----------
+    input_path : `str`
+        The GCS URL to the prefix containing the manifest.json file.
+
+    Returns
+    -------
+    bucket_and_prefix: tuple[str, str]
+        A tuple containing the bucket name and object prefix.
+    """
+    parsed_url = urlparse(input_path)
+    if parsed_url.scheme != "gs":
+        raise ValueError("Input path must start with 'gs://'")
+    bucket_name = parsed_url.netloc
+    object_path = parsed_url.path.lstrip("/")  # Remove leading slash from the path
+    if not bucket_name or not object_path:
+        raise ValueError(f"Invalid GCS path: {input_path}")
+    if not object_path.endswith("/"):
+        object_path += "/"
+    return bucket_name, object_path
+
+
+def read_manifest_from_gcs(input_path: str) -> dict:
+    """Read the manifest.json file from GCS and return it as a Python
+    dictionary.
+
+    Parameters
+    ----------
+    input_path : `str`
+        The GCS path to the directory containing the manifest.json file.
+
+    Returns
+    -------
+    manifest_dict: `dict`
+        The contents of the manifest.json file as a Python dictionary.
+    """
+    # Parse the bucket name and object path from the input_path
+    bucket_name, object_prefix = parse_input_path(input_path)
+
+    # Initialize the GCS client
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(f"{object_prefix}manifest.json")
+
+    # Download and parse the manifest file
+    manifest_content = blob.download_as_text()
+    return json.loads(manifest_content)
+
+
+def run(argv: Optional[list[str]] = None) -> None:
+    """Run the pipeline."""
+    options = PipelineOptions(argv)
+    custom_options = options.view_as(CustomOptions)
+
+    gcp_options = options.view_as(GoogleCloudOptions)
+    options.view_as(SetupOptions).save_main_session = True
+
+    temp_location = gcp_options.temp_location
+    if not temp_location:
+        raise ValueError("GCP temp_location must be set in pipeline options.")
+
+    project_id = gcp_options.project
+
+    dataset_id = custom_options.dataset_id
+    input_path = custom_options.input_path
+
+    try:
+        manifest = read_manifest_from_gcs(input_path)
+        logging.info("Manifest content: %s", json.dumps(manifest))
+    except Exception:
+        logging.exception("Failed to read manifest.json from GCS")
+        raise
+
+    if not manifest.get("table_files"):
+        raise ValueError("Manifest is missing 'table_files' key or it is empty.")
+
+    logging.info(f"Loading table files: {manifest['table_files']}")
+
+    with apache_beam.Pipeline(options=options) as p:
+        for table_name, table_file in manifest["table_files"].items():
+            data = read_parquet(p, input_path, table_file)
+            write_to_bigquery(data, project_id, dataset_id, table_name, temp_location)
+
+
+if __name__ == "__main__":
+    run()

--- a/stage_chunk/teardown.sh
+++ b/stage_chunk/teardown.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -uxo pipefail
 
 if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
   echo "GOOGLE_APPLICATION_CREDENTIALS is not set. Please set it to your service account key file."
@@ -28,12 +28,12 @@ echo "Bucket: ${GCS_BUCKET}"
 echo "Region: ${REGION}"
 
 # Delete Cloud Function
-gcloud functions delete trigger_stage_chunk --region=${REGION} --quiet || true
+gcloud functions delete trigger_stage_chunk --region=${REGION} --quiet
 
 # Delete Flex Template JSON
-gsutil rm -f gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json || true
+gsutil rm -f gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json
 
 # Delete Container Image (optional)
-gcloud container images delete "gcr.io/${GCP_PROJECT}/stage-chunk-image" --quiet --force-delete-tags || true
+gcloud container images delete "gcr.io/${GCP_PROJECT}/stage-chunk-image" --quiet --force-delete-tags
 
 echo "Teardown complete."

--- a/stage_chunk/teardown.sh
+++ b/stage_chunk/teardown.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS is not set. Please set it to your service account key file."
+  exit 1
+fi
+
+if [ -z "${GCP_PROJECT:-}" ]; then
+  echo "GCP_PROJECT is not set. Please set it to your Google Cloud project ID."
+  exit 1
+fi
+
+if [ -z "${REGION:-}" ]; then
+  echo "REGION is not set. Please set it to your Google Cloud region."
+  exit 1
+fi
+
+if [ -z "${GCS_BUCKET:-}" ]; then
+  echo "GCS_BUCKET is not set. Please set it to your Google Cloud Storage bucket name."
+  exit 1
+fi
+
+echo "Teardown started..."
+echo "Project ID: ${GCP_PROJECT}"
+echo "Bucket: ${GCS_BUCKET}"
+echo "Region: ${REGION}"
+
+# Delete Cloud Function
+gcloud functions delete trigger_stage_chunk --region=${REGION} --quiet || true
+
+# Delete Flex Template JSON
+gsutil rm -f gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json || true
+
+# Delete Container Image (optional)
+gcloud container images delete "gcr.io/${GCP_PROJECT}/stage-chunk-image" --quiet --force-delete-tags || true
+
+echo "Teardown complete."


### PR DESCRIPTION
This PR adds a cloud function which triggers a Dataflow job. This job then loads data into BigQuery from parquet files in Google Cloud Storage (GCS). The function itself is triggered by a Pub/Sub event which is published by the `ChunkUploader` in `dax_ppdb`.

This was initially implemented in a [dax_ppdb PR](https://github.com/lsst/dax_ppdb/pull/10) but split off into its own repository. All review comments pertaining to this functionality should be addressed in the version here.