### PR TITLE
DM-50562: Implementation of multi-stage PPDB data ingestion pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# env files
+.env

--- a/promote_chunks/Makefile
+++ b/promote_chunks/Makefile
@@ -1,7 +1,8 @@
 help:
 	@echo "Usage:"
 	@echo "  make function          Deploy the function"
-	@echo "  make deploy            Redeploy the container, function, and Flex template"
+	@echo "  make schedule          Schedule the function to run daily"
+	@echo "  make deploy            Redeploy and schedule the function"
 	@echo "  make teardown          Tear down the function"
 	@echo "  make test              Test the function with a sample call"
 	@echo "  make help              Show this help message"

--- a/promote_chunks/Makefile
+++ b/promote_chunks/Makefile
@@ -11,7 +11,12 @@ function:
 	./deploy-function.sh
 	@echo "Done deploying function."
 
-deploy: function
+schedule:
+	@echo "Scheduling function..."
+	./schedule.sh
+	@echo "Done scheduling function."
+
+deploy: function schedule
 
 teardown:
 	@echo "Tearing down function..."

--- a/promote_chunks/Makefile
+++ b/promote_chunks/Makefile
@@ -1,0 +1,25 @@
+help:
+	@echo "Usage:"
+	@echo "  make function          Deploy the function"
+	@echo "  make deploy            Redeploy the container, function, and Flex template"
+	@echo "  make teardown          Tear down the function"
+	@echo "  make test              Test the function with a sample call"
+	@echo "  make help              Show this help message"
+
+function:
+	@echo "Deploying function..."
+	./deploy-function.sh
+	@echo "Done deploying function."
+
+deploy: function
+
+teardown:
+	@echo "Tearing down function..."
+	./teardown.sh
+	@echo "Done tearing down function."
+
+test:
+	@echo "Testing function with a sample call..."
+	./test-call.sh
+	@echo
+	@echo "Done testing function."

--- a/promote_chunks/deploy-function.sh
+++ b/promote_chunks/deploy-function.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Set the topic name for updating chunk statuses
+TOPIC_NAME="track-chunk-topic"
+
+LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+gcloud functions deploy promote-chunks \
+  --gen2 \
+  --region=us-central1 \
+  --runtime=python311 \
+  --source=. \
+  --entry-point=promote_chunks \
+  --trigger-http \
+  --no-allow-unauthenticated \
+  --service-account="${SERVICE_ACCOUNT_EMAIL}" \
+  --memory=4Gi \
+  --timeout=900s \
+  --set-env-vars "REGION=${GCP_REGION},PROJECT_ID=${GCP_PROJECT},DATASET_ID=${DATASET_ID},DB_HOST=${PPDB_DB_HOST_INTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME}"

--- a/promote_chunks/deploy-function.sh
+++ b/promote_chunks/deploy-function.sh
@@ -2,9 +2,6 @@
 
 set -euxo pipefail
 
-# Set the topic name for updating chunk statuses
-TOPIC_NAME="track-chunk-topic"
-
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 
 gcloud functions deploy promote-chunks \
@@ -18,4 +15,6 @@ gcloud functions deploy promote-chunks \
   --service-account="${SERVICE_ACCOUNT_EMAIL}" \
   --memory=4Gi \
   --timeout=900s \
-  --set-env-vars "REGION=${GCP_REGION},PROJECT_ID=${GCP_PROJECT},DATASET_ID=${DATASET_ID},DB_HOST=${PPDB_DB_HOST_INTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME}"
+  --vpc-connector=ppdb-vpc-connector \
+  --egress-settings=all \
+  --set-env-vars "REGION=${GCP_REGION},PROJECT_ID=${GCP_PROJECT},DATASET_ID=${DATASET_ID},DB_HOST=${PPDB_DB_HOST_INTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME},LOG_LEVEL=${LOG_LEVEL}"

--- a/promote_chunks/main.py
+++ b/promote_chunks/main.py
@@ -24,9 +24,9 @@
 import logging
 
 from flask import Request, jsonify
-from lsst.ppdb.gcp.bq import NoPromotableChunksError, ReplicaChunkPromoter
-from lsst.ppdb.gcp.db import ReplicaChunkDatabase
-from lsst.ppdb.gcp.log_config import setup_logging
+from lsst.dax.ppdbx.gcp.bq import NoPromotableChunksError, ReplicaChunkPromoter
+from lsst.dax.ppdbx.gcp.db import ReplicaChunkDatabase
+from lsst.dax.ppdbx.gcp.log_config import setup_logging
 
 # Setup logging
 setup_logging()

--- a/promote_chunks/main.py
+++ b/promote_chunks/main.py
@@ -1,0 +1,78 @@
+"""Promote APDB replica chunks from staging into production."""
+
+# This file is part of ppdb-cloud-functions.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from flask import Request, jsonify
+from lsst.ppdb.gcp.bq import NoPromotableChunksError, ReplicaChunkPromoter
+from lsst.ppdb.gcp.db import ReplicaChunkDatabase
+from lsst.ppdb.gcp.log_config import setup_logging
+
+# Setup logging
+setup_logging()
+
+# Initialize the chunk tracking database
+_replica_chunk_db = ReplicaChunkDatabase.from_env()
+
+
+def promote_chunks(request: Request):
+    """Promotes APDB replica chunks into production that have been copied into
+    staging tables by the ``ChunkUploader`. Only chunks that are staged and
+    have all prior chunks promoted will be considered for promotion.
+
+    Parameters
+    ----------
+    request : Request
+        The Flask request object containing the payload for promotion. This
+        will typically be empty as the promotion is based on the current state
+        of the database.
+
+    Returns
+    -------
+    Response
+        A JSON response indicating the success or failure of the promotion.
+        This will include the number of chunks promoted and any error messages,
+        if applicable.
+    """
+    promoted_count = 0
+    try:
+        # Fetch a list of promotable chunk IDs from the database
+        promotable_chunks = _replica_chunk_db.get_promotable_chunks()
+
+        # Promote the chunks using the ReplicaChunkPromoter
+        promoter = ReplicaChunkPromoter()
+        promoter.promote_chunks(promotable_chunks)
+
+        # Mark the chunks as promoted in the chunk tracking database
+        promoted_count = _replica_chunk_db.mark_chunks_promoted(promotable_chunks)
+    except NoPromotableChunksError as e:
+        logging.info("No promotable chunks found: %s", str(e))
+        return jsonify(
+            {"ok": True, "message": "No promotable chunks found", "chunks_promoted": 0}
+        ), 200
+    except Exception as e:
+        logging.exception("Error during chunk promotion")
+        return jsonify({"ok": False, "error": str(e), "chunks_promoted": 0}), 500
+    return jsonify(
+        {"ok": True, "mode": "execute", "chunks_promoted": promoted_count}
+    ), 200

--- a/promote_chunks/main.py
+++ b/promote_chunks/main.py
@@ -42,14 +42,14 @@ def promote_chunks(request: Request):
 
     Parameters
     ----------
-    request : Request
+    request : `Request`
         The Flask request object containing the payload for promotion. This
         will typically be empty as the promotion is based on the current state
         of the database.
 
     Returns
     -------
-    Response
+    response: `Response`
         A JSON response indicating the success or failure of the promotion.
         This will include the number of chunks promoted and any error messages,
         if applicable.
@@ -59,9 +59,11 @@ def promote_chunks(request: Request):
         # Fetch a list of promotable chunk IDs from the database
         promotable_chunks = _replica_chunk_db.get_promotable_chunks()
 
+        logging.info("Promotable chunk count: %s", len(promotable_chunks))
+
         # Promote the chunks using the ReplicaChunkPromoter
-        promoter = ReplicaChunkPromoter()
-        promoter.promote_chunks(promotable_chunks)
+        promoter = ReplicaChunkPromoter(promotable_chunks)
+        promoter.promote_chunks()
 
         # Mark the chunks as promoted in the chunk tracking database
         promoted_count = _replica_chunk_db.mark_chunks_promoted(promotable_chunks)

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -1,0 +1,6 @@
+flask
+google-cloud-bigquery
+google-cloud-logging
+google-cloud-storage
+
+lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@tickets/DM-50562

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -1,1 +1,1 @@
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.32
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@main

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -3,4 +3,4 @@ google-cloud-bigquery
 google-cloud-logging
 google-cloud-storage
 
-lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@v0.0.8
+lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@v0.0.19

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -3,4 +3,4 @@ google-cloud-bigquery
 google-cloud-logging
 google-cloud-storage
 
-lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@tickets/DM-50562
+lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@v0.0.8

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -1,1 +1,1 @@
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.28
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.32

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -1,6 +1,1 @@
-flask
-google-cloud-bigquery
-google-cloud-logging
-google-cloud-storage
-
-lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@v0.0.19
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.28

--- a/promote_chunks/schedule.sh
+++ b/promote_chunks/schedule.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Function URL
+FUNCTION_URL=$(gcloud functions describe promote-chunks \
+  --gen2 --region=us-central1 \
+  --format='value(serviceConfig.uri)')
+
+# Daily at 12:00 Chile time
+gcloud scheduler jobs create http promote-chunks-daily \
+  --location=us-central1 \
+  --schedule="0 12 * * *" \
+  --time-zone="America/Santiago" \
+  --http-method=POST \
+  --uri="${FUNCTION_URL}" \
+  --oidc-service-account-email="${SERVICE_ACCOUNT_EMAIL}" \
+  --oidc-token-audience="${FUNCTION_URL}"

--- a/promote_chunks/schedule.sh
+++ b/promote_chunks/schedule.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Function URL
 FUNCTION_URL=$(gcloud functions describe promote-chunks \
   --gen2 --region=us-central1 \
   --format='value(serviceConfig.uri)')
+
+# Delete the existing Cloud Scheduler job if it exists
+gcloud scheduler jobs delete promote-chunks-daily \
+  --location=us-central1 || true
 
 # Daily at 12:00 Chile time
 gcloud scheduler jobs create http promote-chunks-daily \

--- a/promote_chunks/teardown.sh
+++ b/promote_chunks/teardown.sh
@@ -7,6 +7,11 @@ if [ -z "${GCP_REGION:-}" ]; then
   exit 1
 fi
 
+# Delete the promote chunks function
 gcloud functions delete promote-chunks \
   --gen2 \
   --region=$GCP_REGION
+
+# Deleted scheduled run
+gcloud scheduler jobs delete promote-chunks-daily \
+  --location=us-central1

--- a/promote_chunks/teardown.sh
+++ b/promote_chunks/teardown.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uxo pipefail
+set -ux
 
 if [ -z "${GCP_REGION:-}" ]; then
   echo "REGION is not set. Please set it to your Google Cloud region."

--- a/promote_chunks/teardown.sh
+++ b/promote_chunks/teardown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -uxo pipefail
+
+if [ -z "${GCP_REGION:-}" ]; then
+  echo "REGION is not set. Please set it to your Google Cloud region."
+  exit 1
+fi
+
+gcloud functions delete promote-chunks \
+  --gen2 \
+  --region=$GCP_REGION

--- a/promote_chunks/test-call.sh
+++ b/promote_chunks/test-call.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+FUNC="promote-chunks"
+
+# 1. Get the function's URL
+URL="$(gcloud functions describe "$FUNC" --gen2 --region="$GCP_REGION" \
+  --format='value(serviceConfig.uri)')"
+
+# 2. Login as the SA
+gcloud config set account ${SERVICE_ACCOUNT_EMAIL}
+
+# 3. Set the environment variable for the dev token
+TOKEN="$(gcloud auth print-identity-token --audiences="$URL")"
+
+# 4. Invoke the function with the dev token
+curl -X POST "$URL" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" 
+
+# 5. Restore the user account after testing
+gcloud config set account ${USER_EMAIL}

--- a/promote_chunks/test-call.sh
+++ b/promote_chunks/test-call.sh
@@ -3,20 +3,14 @@ set -euxo pipefail
 
 FUNC="promote-chunks"
 
-# 1. Get the function's URL
+# Get the function's URL
 URL="$(gcloud functions describe "$FUNC" --gen2 --region="$GCP_REGION" \
   --format='value(serviceConfig.uri)')"
 
-# 2. Login as the SA
-gcloud config set account ${SERVICE_ACCOUNT_EMAIL}
-
-# 3. Set the environment variable for the dev token
+# Set the environment variable for the dev token
 TOKEN="$(gcloud auth print-identity-token --audiences="$URL")"
 
-# 4. Invoke the function with the dev token
+# Invoke the function with the dev token
 curl -X POST "$URL" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" 
-
-# 5. Restore the user account after testing
-gcloud config set account ${USER_EMAIL}

--- a/stage_chunk/Dockerfile
+++ b/stage_chunk/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /dataflow/template
 COPY stage_chunk_beam_job.py .
 
 # Install dependencies
-RUN pip install --no-cache-dir google-cloud-storage
+RUN pip install --no-cache-dir google-cloud-logging google-cloud-storage google-cloud-pubsub
 
 # Set required environment variable for Flex Templates
 ENV FLEX_TEMPLATE_PYTHON_PY_FILE=stage_chunk_beam_job.py

--- a/stage_chunk/build-container.sh
+++ b/stage_chunk/build-container.sh
@@ -2,11 +2,6 @@
 
 set -euxo pipefail
 
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
-  echo "GOOGLE_APPLICATION_CREDENTIALS is unset or empty. Please set it to your service account key file."
-  exit 1
-fi
-
 if [ -z "${GCP_PROJECT:-}" ]; then
   echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
   exit 1

--- a/stage_chunk/build-flex-template.sh
+++ b/stage_chunk/build-flex-template.sh
@@ -2,11 +2,6 @@
 
 set -euxo pipefail
 
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
-  echo "GOOGLE_APPLICATION_CREDENTIALS is unset or empty. Please set it to your service account key file."
-  exit 1
-fi
-
 if [ -z "${GCP_PROJECT:-}" ]; then
   echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
   exit 1

--- a/stage_chunk/deploy-function.sh
+++ b/stage_chunk/deploy-function.sh
@@ -7,13 +7,13 @@ if [ -z "${GCP_PROJECT:-}" ]; then
   exit 1
 fi
 
-if [ -z "${REGION:-}" ]; then
-  echo "REGION is unset or empty. Please set it to your Google Cloud region."
+if [ -z "${GCS_BUCKET:-}" ]; then
+  echo "GCS_BUCKET is unset or empty. Please set it to your Google Cloud Storage bucket name."
   exit 1
 fi
 
-if [ -z "${DATAFLOW_TEMPLATE_PATH:-}" ]; then
-  echo "DATAFLOW_TEMPLATE_PATH is unset or empty. Please set it to your Dataflow template path."
+if [ -z "${REGION:-}" ]; then
+  echo "REGION is unset or empty. Please set it to your Google Cloud region."
   exit 1
 fi
 
@@ -27,10 +27,9 @@ if [ -z "${DATASET_ID:-}" ]; then
   exit 1
 fi
 
-if [ -z "${TEMP_LOCATION:-}" ]; then
-  echo "TEMP_LOCATION is unset or empty. Please set it to your Google Cloud temporary location."
-  exit 1
-fi
+# Set Dataflow template path and temp location by convention
+DATAFLOW_TEMPLATE_PATH="gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json"
+TEMP_LOCATION="gs://${GCS_BUCKET}/dataflow/temp"
 
 # Deploy the Cloud Function
 gcloud functions deploy trigger_stage_chunk \

--- a/stage_chunk/deploy-function.sh
+++ b/stage_chunk/deploy-function.sh
@@ -6,13 +6,18 @@ set -euxo pipefail
 DATAFLOW_TEMPLATE_PATH="gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json"
 TEMP_LOCATION="gs://${GCS_BUCKET}/dataflow/temp"
 
+# Set the topic name for updating chunk statuses
+TOPIC_NAME="track-chunk-topic"
+
+LOG_LEVEL=${LOG_LEVEL:-DEBUG}
+
 # Deploy the Cloud Function
 gcloud functions deploy trigger_stage_chunk \
   --runtime=python311 \
-  --region=${REGION} \
+  --region=${GCP_REGION} \
   --source=. \
   --entry-point=trigger_stage_chunk \
   --service-account=${SERVICE_ACCOUNT_EMAIL} \
   --trigger-topic=stage-chunk-topic \
-  --set-env-vars "PROJECT_ID=${GCP_PROJECT},REGION=${REGION},SERVICE_ACCOUNT_EMAIL=${SERVICE_ACCOUNT_EMAIL},TEMP_LOCATION=${TEMP_LOCATION},DATAFLOW_TEMPLATE_PATH=${DATAFLOW_TEMPLATE_PATH}" \
+  --set-env-vars "PROJECT_ID=${GCP_PROJECT},REGION=${GCP_REGION},SERVICE_ACCOUNT_EMAIL=${SERVICE_ACCOUNT_EMAIL},TEMP_LOCATION=${TEMP_LOCATION},DATAFLOW_TEMPLATE_PATH=${DATAFLOW_TEMPLATE_PATH},TOPIC_NAME=${TOPIC_NAME},LOG_LEVEL=${LOG_LEVEL}" \
   --gen2

--- a/stage_chunk/deploy-function.sh
+++ b/stage_chunk/deploy-function.sh
@@ -2,11 +2,6 @@
 
 set -euxo pipefail
 
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
-  echo "GOOGLE_APPLICATION_CREDENTIALS is unset or empty. Please set it to your service account key file."
-  exit 1
-fi
-
 if [ -z "${GCP_PROJECT:-}" ]; then
   echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
   exit 1

--- a/stage_chunk/deploy-function.sh
+++ b/stage_chunk/deploy-function.sh
@@ -2,31 +2,6 @@
 
 set -euxo pipefail
 
-if [ -z "${GCP_PROJECT:-}" ]; then
-  echo "GCP_PROJECT is unset or empty. Please set it to your Google Cloud project ID."
-  exit 1
-fi
-
-if [ -z "${GCS_BUCKET:-}" ]; then
-  echo "GCS_BUCKET is unset or empty. Please set it to your Google Cloud Storage bucket name."
-  exit 1
-fi
-
-if [ -z "${REGION:-}" ]; then
-  echo "REGION is unset or empty. Please set it to your Google Cloud region."
-  exit 1
-fi
-
-if [ -z "${SERVICE_ACCOUNT_EMAIL:-}" ]; then
-  echo "SERVICE_ACCOUNT_EMAIL is unset or empty. Please set it to your Google Cloud service account email."
-  exit 1
-fi
-
-if [ -z "${DATASET_ID:-}" ]; then
-  echo "DATASET_ID is unset or empty. Please set it to your Google Cloud dataset ID."
-  exit 1
-fi
-
 # Set Dataflow template path and temp location by convention
 DATAFLOW_TEMPLATE_PATH="gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json"
 TEMP_LOCATION="gs://${GCS_BUCKET}/dataflow/temp"

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -30,9 +30,8 @@ from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.functions_v1.context import Context
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-
-from lsst.ppdb.gcp.log_config import setup_logging
-from lsst.ppdb.gcp.env import require_env
+from lsst.dax.ppdbx.gcp.env import require_env
+from lsst.dax.ppdbx.gcp.log_config import setup_logging
 
 setup_logging()
 

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -97,7 +97,7 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
         "launchParameter": {
             "jobName": job_name,
             "containerSpecGcsPath": DATAFLOW_TEMPLATE_PATH,
-            "parameters": {"input_path": input_path, "dataset_id": dataset_id},
+            "parameters": {"chunk_id": chunk_id, "input_path": input_path, "dataset_id": dataset_id},
             "environment": {
                 "serviceAccountEmail": SERVICE_ACCOUNT_EMAIL,
                 "tempLocation": TEMP_LOCATION,

--- a/stage_chunk/metadata.json
+++ b/stage_chunk/metadata.json
@@ -3,9 +3,9 @@
     "description": "Loads parquet chunks into BigQuery",
     "parameters": [
       {
-        "name": "input_path",
-        "label": "GCS input path",
-        "helpText": "Path to directory containing Parquet files",
+        "name": "folder",
+        "label": "GCS folder",
+        "helpText": "GCS URI pointing to prefix containing Parquet files",
         "paramType": "TEXT",
         "isOptional": false
       },

--- a/stage_chunk/metadata.json
+++ b/stage_chunk/metadata.json
@@ -15,6 +15,13 @@
         "helpText": "Target BigQuery dataset",
         "paramType": "TEXT",
         "isOptional": false
+      },
+      {
+        "name": "chunk_id",
+        "label": "Chunk ID",
+        "helpText": "ID of the chunk being processed",
+        "paramType": "TEXT",
+        "isOptional": false
       }
     ]
   }

--- a/stage_chunk/metadata.json
+++ b/stage_chunk/metadata.json
@@ -22,6 +22,13 @@
         "helpText": "ID of the chunk being processed",
         "paramType": "TEXT",
         "isOptional": false
+      },
+      {
+        "name": "topic_name",
+        "label": "Pub/Sub Topic Name",
+        "helpText": "Name of the Pub/Sub topic to publish chunk status updates",
+        "paramType": "TEXT",
+        "isOptional": false
       }
     ]
   }

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -5,4 +5,4 @@ google-cloud-functions
 google-cloud-storage
 google-cloud-pubsub
 
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.32
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@main

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -5,4 +5,4 @@ google-cloud-functions
 google-cloud-storage
 google-cloud-pubsub
 
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.28
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.32

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -1,6 +1,6 @@
 functions-framework
-google-auth
 google-api-python-client
-google-cloud-secret-manager
-psycopg2-binary
-sqlalchemy
+google-auth
+google-cloud-logging
+
+lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@tickets/DM-50562

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -1,6 +1,8 @@
-functions-framework
-google-api-python-client
 google-auth
-google-cloud-logging
+google-api-core
+google-api-python-client
+google-cloud-functions
+google-cloud-storage
+google-cloud-pubsub
 
-lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@tickets/DM-50562
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.28

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -1,3 +1,6 @@
 functions-framework
 google-auth
 google-api-python-client
+google-cloud-secret-manager
+psycopg2-binary
+sqlalchemy

--- a/stage_chunk/stage_chunk_beam_job.py
+++ b/stage_chunk/stage_chunk_beam_job.py
@@ -34,9 +34,12 @@ from apache_beam.options.pipeline_options import (
     PipelineOptions,
     SetupOptions,
 )
+from google.cloud import logging as cloud_logging
 from google.cloud import pubsub_v1, storage
 
-logging.basicConfig(level=logging.INFO)
+# Configure Google Cloud logging
+cloud_logging.Client().setup_logging()
+logging.getLogger().setLevel(logging.INFO)
 
 
 class BeamSuppressUpdateDestinationSchemaWarning(logging.Filter):

--- a/stage_chunk/teardown.sh
+++ b/stage_chunk/teardown.sh
@@ -28,7 +28,7 @@ echo "Bucket: ${GCS_BUCKET}"
 echo "Region: ${GCP_REGION}"
 
 # Delete Cloud Function
-gcloud functions delete trigger_stage_chunk --region=${RGCP_REGION} --quiet
+gcloud functions delete trigger_stage_chunk --region=${GCP_REGION} --quiet
 
 # Delete Flex Template JSON
 gsutil rm -f gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json

--- a/stage_chunk/teardown.sh
+++ b/stage_chunk/teardown.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uxo pipefail
+set -ux
 
 if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
   echo "GOOGLE_APPLICATION_CREDENTIALS is not set. Please set it to your service account key file."

--- a/stage_chunk/teardown.sh
+++ b/stage_chunk/teardown.sh
@@ -12,7 +12,7 @@ if [ -z "${GCP_PROJECT:-}" ]; then
   exit 1
 fi
 
-if [ -z "${REGION:-}" ]; then
+if [ -z "${GCP_REGION:-}" ]; then
   echo "REGION is not set. Please set it to your Google Cloud region."
   exit 1
 fi
@@ -25,10 +25,10 @@ fi
 echo "Teardown started..."
 echo "Project ID: ${GCP_PROJECT}"
 echo "Bucket: ${GCS_BUCKET}"
-echo "Region: ${REGION}"
+echo "Region: ${GCP_REGION}"
 
 # Delete Cloud Function
-gcloud functions delete trigger_stage_chunk --region=${REGION} --quiet
+gcloud functions delete trigger_stage_chunk --region=${RGCP_REGION} --quiet
 
 # Delete Flex Template JSON
 gsutil rm -f gs://${GCS_BUCKET}/templates/stage_chunk_flex_template.json

--- a/track_chunk/Makefile
+++ b/track_chunk/Makefile
@@ -1,0 +1,21 @@
+help:
+	@echo "Usage:"
+	@echo "  make deploy            Redeploy the function"
+	@echo "  make teardown          Tear down the function"
+	@echo "  make logs              Show the last 50 logs for the function"
+	@echo "  make help              Show this help message"
+
+function:
+	@echo "Deploying function..."
+	./deploy-function.sh
+	@echo "Done deploying function."
+
+deploy: function
+
+teardown:
+	@echo "Tearing down function..."
+	./teardown.sh
+	@echo "Done tearing down function."
+
+logs:
+	gcloud functions logs read update_chunk_status --region=us-central1 --limit=50 | less

--- a/track_chunk/deploy-function.sh
+++ b/track_chunk/deploy-function.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Deploy the Cloud Function
+gcloud functions deploy track_chunk \
+  --runtime=python311 \
+  --region=${GCP_REGION} \
+  --source=. \
+  --entry-point=track_chunk \
+  --service-account=${SERVICE_ACCOUNT_EMAIL} \
+  --trigger-topic=track-chunk-topic \
+  --set-env-vars "PROJECT_ID=${GCP_PROJECT},DB_HOST=${PPDB_DB_HOST_INTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME}" \
+  --vpc-connector=ppdb-vpc-connector \
+  --egress-settings=all \
+  --gen2

--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -25,8 +25,8 @@ import json
 import logging
 from typing import Any
 
-from lsst.ppdb.gcp.db import ReplicaChunkDatabase
-from lsst.ppdb.gcp.log_config import setup_logging
+from lsst.dax.ppdbx.gcp.db import ReplicaChunkDatabase
+from lsst.dax.ppdbx.gcp.log_config import setup_logging
 
 setup_logging()
 
@@ -34,7 +34,6 @@ db = ReplicaChunkDatabase.from_env()
 
 
 def track_chunk(event: dict[str, Any], context: Any) -> None:
-
     try:
         try:
             message = base64.b64decode(event["data"]).decode("utf-8")

--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -1,0 +1,181 @@
+# This file is part of ppdb-cloud-functions
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import base64
+import binascii
+import json
+import logging
+import os
+from typing import Any
+
+import google.cloud.logging
+from google.cloud import secretmanager
+from sqlalchemy import create_engine, insert, update, MetaData, Table
+from sqlalchemy.engine import Engine
+
+# Set up Google Cloud Logging
+client = google.cloud.logging.Client()
+client.setup_logging()
+logging.getLogger().setLevel(logging.DEBUG)
+
+# Required environment variables
+PROJECT_ID = os.environ["PROJECT_ID"]
+DB_HOST = os.environ["DB_HOST"]
+DB_NAME = os.environ["DB_NAME"]
+DB_USER = os.environ["DB_USER"]
+DB_SCHEMA = os.environ["DB_SCHEMA"]
+
+# Module-level cache for engine and table
+_engine: Engine | None = None
+_table: Table | None = None
+
+
+def get_db_password() -> str:
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{PROJECT_ID}/secrets/ppdb-db-password/versions/latest"
+    response = client.access_secret_version(request={"name": name})
+    return response.payload.data.decode("UTF-8")
+
+
+def get_engine() -> Engine:
+    global _engine
+    if _engine is None:
+        db_password = get_db_password()
+        db_url = (
+            f"postgresql+psycopg2://{DB_USER}:{db_password}@{DB_HOST}:5432/{DB_NAME}"
+        )
+        logging.info(
+            "Connecting to database at: %s",
+            f"postgresql+psycopg2://{DB_USER}@{DB_HOST}:5432/{DB_NAME}",
+        )
+        _engine = create_engine(
+            db_url,
+            pool_pre_ping=True,
+            connect_args={"options": f"-c search_path={DB_SCHEMA}"},
+        )
+    return _engine
+
+
+def get_table() -> Table:
+    global _table
+    if _table is None:
+        metadata = MetaData()
+        _table = Table("PpdbReplicaChunk", metadata, autoload_with=get_engine())
+    return _table
+
+
+def _update(
+    engine: Engine, table: Table, chunk_id: int, values: dict[str, Any]
+) -> None:
+    logging.info(
+        "Preparing to update replica chunk %d with values: %s", chunk_id, values
+    )
+    stmt = update(table).where(table.c.apdb_replica_chunk == chunk_id).values(values)
+    with engine.begin() as conn:
+        result = conn.execute(stmt)
+        affected_rows = result.rowcount
+
+    new_status = values.get("status")
+    if affected_rows == 0:
+        logging.warning(
+            "No rows updated for replica chunk %s with status '%s'",
+            chunk_id,
+            new_status,
+        )
+    else:
+        logging.info(
+            "Successfully updated %d row(s) for replica chunk %s to status '%s'",
+            affected_rows,
+            chunk_id,
+            new_status,
+        )
+
+
+def _insert(
+    engine: Engine, table: Table, chunk_id: int, values: dict[str, Any]
+) -> None:
+    insert_values = {"apdb_replica_chunk": chunk_id, **values}
+    logging.info(
+        "Preparing to insert replica chunk %d with values: %s", chunk_id, insert_values
+    )
+    stmt = insert(table).values(insert_values)
+    with engine.begin() as conn:
+        result = conn.execute(stmt)
+        affected_rows = result.rowcount
+
+    new_status = insert_values.get("status")
+    if affected_rows == 0:
+        logging.error(
+            "Expected to insert replica chunk %s with status '%s', but no rows were inserted.",
+            chunk_id,
+            new_status,
+        )
+        raise RuntimeError(
+            f"No rows inserted for apdb_replica_chunk={chunk_id} - insert silently failed."
+        )
+    else:
+        logging.info(
+            "Successfully inserted %d row(s) for replica chunk %s with status '%s'",
+            affected_rows,
+            chunk_id,
+            new_status,
+        )
+
+
+def track_chunk(event: dict[str, Any], context: Any) -> None:
+    try:
+        try:
+            message = base64.b64decode(event["data"]).decode("utf-8")
+        except (KeyError, binascii.Error, UnicodeDecodeError) as e:
+            raise Exception("Malformed or missing Pub/Sub data payload") from e
+
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError as e:
+            raise Exception("Failed to decode JSON from Pub/Sub message") from e
+
+        logging.info("Received Pub/Sub message: %s", data)
+
+        operation = data.get("operation")
+        if not operation:
+            raise KeyError("Missing 'operation' key in Pub/Sub message")
+        if operation not in ["insert", "update"]:
+            raise ValueError(f"Unsupported operation: {operation}")
+
+        values = data.get("values")
+        if not values:
+            raise ValueError("No 'values' key found in Pub/Sub message")
+
+        if "apdb_replica_chunk" not in data:
+            raise KeyError("Missing 'apdb_replica_chunk' in message")
+
+        chunk_id = data["apdb_replica_chunk"]
+
+        engine = get_engine()
+        table = get_table()
+
+        if operation == "update":
+            _update(engine, table, chunk_id, values)
+        elif operation == "insert":
+            _insert(engine, table, chunk_id, values)
+
+    except Exception:
+        logging.exception("Error processing Pub/Sub message")

--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -23,124 +23,18 @@ import base64
 import binascii
 import json
 import logging
-import os
 from typing import Any
 
-import google.cloud.logging
-from google.cloud import secretmanager
-from sqlalchemy import create_engine, insert, update, MetaData, Table
-from sqlalchemy.engine import Engine
+from lsst.ppdb.gcp.db import ReplicaChunkDatabase
+from lsst.ppdb.gcp.log_config import setup_logging
 
-# Set up Google Cloud Logging
-client = google.cloud.logging.Client()
-client.setup_logging()
-logging.getLogger().setLevel(logging.DEBUG)
+setup_logging()
 
-# Required environment variables
-PROJECT_ID = os.environ["PROJECT_ID"]
-DB_HOST = os.environ["DB_HOST"]
-DB_NAME = os.environ["DB_NAME"]
-DB_USER = os.environ["DB_USER"]
-DB_SCHEMA = os.environ["DB_SCHEMA"]
-
-# Module-level cache for engine and table
-_engine: Engine | None = None
-_table: Table | None = None
-
-
-def get_db_password() -> str:
-    client = secretmanager.SecretManagerServiceClient()
-    name = f"projects/{PROJECT_ID}/secrets/ppdb-db-password/versions/latest"
-    response = client.access_secret_version(request={"name": name})
-    return response.payload.data.decode("UTF-8")
-
-
-def get_engine() -> Engine:
-    global _engine
-    if _engine is None:
-        db_password = get_db_password()
-        db_url = (
-            f"postgresql+psycopg2://{DB_USER}:{db_password}@{DB_HOST}:5432/{DB_NAME}"
-        )
-        logging.info(
-            "Connecting to database at: %s",
-            f"postgresql+psycopg2://{DB_USER}@{DB_HOST}:5432/{DB_NAME}",
-        )
-        _engine = create_engine(
-            db_url,
-            pool_pre_ping=True,
-            connect_args={"options": f"-c search_path={DB_SCHEMA}"},
-        )
-    return _engine
-
-
-def get_table() -> Table:
-    global _table
-    if _table is None:
-        metadata = MetaData()
-        _table = Table("PpdbReplicaChunk", metadata, autoload_with=get_engine())
-    return _table
-
-
-def _update(
-    engine: Engine, table: Table, chunk_id: int, values: dict[str, Any]
-) -> None:
-    logging.info(
-        "Preparing to update replica chunk %d with values: %s", chunk_id, values
-    )
-    stmt = update(table).where(table.c.apdb_replica_chunk == chunk_id).values(values)
-    with engine.begin() as conn:
-        result = conn.execute(stmt)
-        affected_rows = result.rowcount
-
-    new_status = values.get("status")
-    if affected_rows == 0:
-        logging.warning(
-            "No rows updated for replica chunk %s with status '%s'",
-            chunk_id,
-            new_status,
-        )
-    else:
-        logging.info(
-            "Successfully updated %d row(s) for replica chunk %s to status '%s'",
-            affected_rows,
-            chunk_id,
-            new_status,
-        )
-
-
-def _insert(
-    engine: Engine, table: Table, chunk_id: int, values: dict[str, Any]
-) -> None:
-    insert_values = {"apdb_replica_chunk": chunk_id, **values}
-    logging.info(
-        "Preparing to insert replica chunk %d with values: %s", chunk_id, insert_values
-    )
-    stmt = insert(table).values(insert_values)
-    with engine.begin() as conn:
-        result = conn.execute(stmt)
-        affected_rows = result.rowcount
-
-    new_status = insert_values.get("status")
-    if affected_rows == 0:
-        logging.error(
-            "Expected to insert replica chunk %s with status '%s', but no rows were inserted.",
-            chunk_id,
-            new_status,
-        )
-        raise RuntimeError(
-            f"No rows inserted for apdb_replica_chunk={chunk_id} - insert silently failed."
-        )
-    else:
-        logging.info(
-            "Successfully inserted %d row(s) for replica chunk %s with status '%s'",
-            affected_rows,
-            chunk_id,
-            new_status,
-        )
+db = ReplicaChunkDatabase.from_env()
 
 
 def track_chunk(event: dict[str, Any], context: Any) -> None:
+
     try:
         try:
             message = base64.b64decode(event["data"]).decode("utf-8")
@@ -169,13 +63,10 @@ def track_chunk(event: dict[str, Any], context: Any) -> None:
 
         chunk_id = data["apdb_replica_chunk"]
 
-        engine = get_engine()
-        table = get_table()
-
         if operation == "update":
-            _update(engine, table, chunk_id, values)
+            db.update(chunk_id, values)
         elif operation == "insert":
-            _insert(engine, table, chunk_id, values)
+            db.insert(chunk_id, values)
 
     except Exception:
         logging.exception("Error processing Pub/Sub message")

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,0 +1,6 @@
+functions-framework
+google-api-python-client
+google-cloud-logging
+google-cloud-secret-manager
+psycopg2-binary
+sqlalchemy

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -4,3 +4,5 @@ google-cloud-logging
 google-cloud-secret-manager
 psycopg2-binary
 sqlalchemy
+
+lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@tickets/DM-50562

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,1 +1,1 @@
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.32
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@main

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,7 +1,10 @@
 functions-framework
-google-api-python-client
+google-auth
+google-cloud-bigquery
 google-cloud-logging
+google-cloud-pubsub
 google-cloud-secret-manager
+google-cloud-storage
 psycopg2-binary
 sqlalchemy
 

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,11 +1,1 @@
-functions-framework
-google-auth
-google-cloud-bigquery
-google-cloud-logging
-google-cloud-pubsub
-google-cloud-secret-manager
-google-cloud-storage
-psycopg2-binary
-sqlalchemy
-
-lsst-ppdb-gcp @ git+https://github.com/lsst-dm/ppdb-gcp@tickets/DM-50562
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.28

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,1 +1,1 @@
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.28
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@v0.0.32

--- a/track_chunk/teardown.sh
+++ b/track_chunk/teardown.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -uxo pipefail
+
+# Delete Cloud Function
+gcloud functions delete track_chunk --region=${GCP_REGION} --quiet
+
+echo "Teardown complete."

--- a/track_chunk/teardown.sh
+++ b/track_chunk/teardown.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uxo pipefail
+set -ux
 
 # Delete Cloud Function
 gcloud functions delete track_chunk --region=${GCP_REGION} --quiet


### PR DESCRIPTION
The main functionality added by this PR is the execution of the "promotion" step for APDB replica chunks, which copies data from staging tables into production. The function for staging chunks was rewritten to copy into the staging tables instead of directly into production.

**Major Changes**

- Added the `promote_chunks` function which promotes APDB replica chunks from staging tables to production
  - This uses the `ReplicaChunkPromoter` in the `db` module of `dax_ppdbx_gcp` for the implementation. 
  - Configuration was included for activating this function on a schedule in the `promote_chunks/schedule.sh` script. The script schedules the promotion process for once a day at noon, Santiago time (Actual execution schedule for production is TBD.).
- Revised the `stage_chunks` function so that it copies data into staging tables rather than directly into production tables.
  - The main updates were to `stage_chunks/stage_chunk_beam_job.py` which implements the Dataflow job for performing this task.
- Added a `track_chunk` function which allows updating the status of a replica chunk using a Pub/Sub event. 
  - This was done mainly to reduce direct dependency on the Postgres database.
  - It is not used uniformly across all functions, as direct DB calls make more sense for certain updates. (The final architecture for this may be modified from what it is, currently.)

**Minor Changes**

- Removed some unnecessary environment variable checks in function scripts and renamed a few variables
- Reworked control flow and error handling in several functions
- General Python code and bash script cleanup, etc.