### PR TITLE
DM-53023: Skip staging the data for tables with zero row count

### DIFF
--- a/promote_chunks/deploy-function.sh
+++ b/promote_chunks/deploy-function.sh
@@ -15,6 +15,7 @@ gcloud functions deploy promote-chunks \
   --service-account="${SERVICE_ACCOUNT_EMAIL}" \
   --memory=4Gi \
   --timeout=900s \
-  --vpc-connector=ppdb-vpc-connector \
-  --egress-settings=all \
-  --set-env-vars "REGION=${GCP_REGION},PROJECT_ID=${GCP_PROJECT},DATASET_ID=${DATASET_ID},DB_HOST=${PPDB_DB_HOST_INTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME},LOG_LEVEL=${LOG_LEVEL}"
+  --set-env-vars "REGION=${GCP_REGION},PROJECT_ID=${GCP_PROJECT},DATASET_ID=${DATASET_ID},DB_HOST=${PPDB_DB_HOST_EXTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME},LOG_LEVEL=${LOG_LEVEL}"
+
+#  --egress-settings=all \
+#  --vpc-connector=ppdb-connector \

--- a/promote_chunks/requirements.txt
+++ b/promote_chunks/requirements.txt
@@ -1,1 +1,1 @@
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@main
+lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@tickets/DM-53023

--- a/stage_chunk/stage_chunk_beam_job.py
+++ b/stage_chunk/stage_chunk_beam_job.py
@@ -302,7 +302,10 @@ def run(argv: Optional[list[str]] = None) -> None:
     logging.info(f"Loading table files: {manifest['table_data'].keys()}")
 
     with apache_beam.Pipeline(options=options) as p:
-        for table_name in manifest["table_data"].keys():
+        for table_name, table_data in manifest["table_data"].items():
+            if table_data["row_count"] == 0:
+                logging.info(f"Skipping empty table {table_name}")
+                continue
             table_file = f"{table_name}.parquet"
             data = read_parquet(p, folder, table_file)
             staging_table_name = get_staging_table_name(table_name)

--- a/track_chunk/deploy-function.sh
+++ b/track_chunk/deploy-function.sh
@@ -10,7 +10,8 @@ gcloud functions deploy track_chunk \
   --entry-point=track_chunk \
   --service-account=${SERVICE_ACCOUNT_EMAIL} \
   --trigger-topic=track-chunk-topic \
-  --set-env-vars "PROJECT_ID=${GCP_PROJECT},DB_HOST=${PPDB_DB_HOST_INTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME}" \
-  --vpc-connector=ppdb-vpc-connector \
-  --egress-settings=all \
+  --set-env-vars "PROJECT_ID=${GCP_PROJECT},DB_HOST=${PPDB_DB_HOST_EXTERNAL},DB_USER=${PPDB_DB_USER},DB_NAME=${PPDB_DB_NAME},DB_SCHEMA=${PPDB_SCHEMA_NAME}" \
   --gen2
+
+#  --vpc-connector=ppdb-vpc-connector \
+#  --egress-settings=all \


### PR DESCRIPTION
This fixes an issue where tables with no rows were causing errors in the data ingestion for staging. These are currently included in the uploaded manifest as a table with `row_count: 0`. This PR is an interim solution which will simply skip these tables.

This does not represent an anomalous state and may not even need to be loaded. For now, the fact that there were no rows is logged before the table is skipped but this may be removed in the future (or set to debug level).