### PR TITLE
DM-54681: Update to use multiple datasets plus additional fixes and improvements

### DIFF
--- a/promote_chunks/deploy-function.sh
+++ b/promote_chunks/deploy-function.sh
@@ -15,6 +15,6 @@ gcloud functions deploy promote-chunks \
   --trigger-http \
   --no-allow-unauthenticated \
   --service-account="${SERVICE_ACCOUNT_EMAIL}" \
-  --memory=4Gi \
+  --memory=16Gi \
   --timeout=900s \
   --set-env-vars "PPDB_CONFIG_URI=${PPDB_CONFIG_URI},PPDB_USE_SECRET_MANAGER=true"

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -52,7 +52,12 @@ TEMP_LOCATION = os.environ["TEMP_LOCATION"]
 TOPIC_NAME = os.environ["TOPIC_NAME"]
 
 _credentials, _ = google.auth.default()
-_dataflow_client = build("dataflow", "v1b3", credentials=_credentials)
+_dataflow_client = build(
+    "dataflow",
+    "v1b3",
+    credentials=_credentials,
+    cache_discovery=False,
+)
 
 
 def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -33,14 +33,17 @@ from google.cloud.functions_v1.context import Context
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-# Configure cloud logging
+# Configure cloud logging.
 client = cloud_logging.Client()
 client.setup_logging()  # Redirects standard logging to Cloud Logging
 log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
 log_level = getattr(logging, log_level_str, logging.INFO)
 logging.getLogger().setLevel(log_level)
 
-# Read required environment variables
+# Silence noisy warnings from
+logging.getLogger("google_auth_httplib2").setLevel(logging.ERROR)
+
+# Read required environment variables.
 PROJECT_ID = os.environ["PROJECT_ID"]
 DATAFLOW_TEMPLATE_PATH = os.environ["DATAFLOW_TEMPLATE_PATH"]
 REGION = os.environ["REGION"]

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -40,7 +40,7 @@ log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
 log_level = getattr(logging, log_level_str, logging.INFO)
 logging.getLogger().setLevel(log_level)
 
-# Silence noisy warnings from
+# Silence noisy warnings from google-auth-httplib2.
 logging.getLogger("google_auth_httplib2").setLevel(logging.ERROR)
 
 # Read required environment variables.

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -91,6 +91,37 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
             extra={"json_fields": {"event": event_name, **log_fields, **fields}},
         )
 
+    def handle_error(e: Exception) -> bool:
+        """Log a job-submission failure and report whether it is retryable."""
+        extra_fields: dict[str, Any] = {}
+        if isinstance(e, HttpError):
+            retryable = e.resp.status in (429, 500, 503)
+            extra_fields["http_status"] = e.resp.status
+        elif isinstance(e, GoogleAPICallError):
+            retryable = True
+        else:
+            retryable = False
+
+        if retryable:
+            level = logging.WARNING
+            log_message = "Retryable error during job submission"
+            event_name = "retryable_error"
+        else:
+            level = logging.ERROR
+            log_message = "Non-retryable error during job submission"
+            event_name = "non_retryable_error"
+
+        log_event(
+            level,
+            log_message,
+            event_name,
+            exc_info=True,
+            error=str(e),
+            error_type=type(e).__name__,
+            **extra_fields,
+        )
+        return retryable
+
     try:
         message = base64.b64decode(event["data"]).decode("utf-8")
     except Exception:
@@ -206,41 +237,9 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
             dataflow_job_id=job_id,
             dataflow_job_name=job_name,
         )
-    except HttpError as e:
-        retryable = e.resp.status in (429, 500, 503)
-        log_event(
-            logging.WARNING if retryable else logging.ERROR,
-            "Retryable HTTP error" if retryable else "Non-retryable HTTP error",
-            "retryable_http_error" if retryable else "non_retryable_http_error",
-            exc_info=True,
-            http_status=e.resp.status,
-            error=str(e),
-            error_type=type(e).__name__,
-        )
-        if retryable:
-            raise  # Will trigger retry
-        return  # Acknowledge message
-
-    except GoogleAPICallError as e:
-        log_event(
-            logging.WARNING,
-            "Retryable GCP API error",
-            "gcp_api_error",
-            exc_info=True,
-            error=str(e),
-            error_type=type(e).__name__,
-        )
-        raise  # Will trigger retry
-
     except Exception as e:
-        log_event(
-            logging.ERROR,
-            "Unexpected error during job submission",
-            "unexpected_error",
-            exc_info=True,
-            error=str(e),
-            error_type=type(e).__name__,
-        )
+        if handle_error(e):
+            raise  # Will trigger retry
         return  # Acknowledge message
 
     return

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -22,27 +22,31 @@
 import base64
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
 
 import google.auth
 from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import logging as cloud_logging
 from google.cloud.functions_v1.context import Context
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from lsst.dax.ppdbx.gcp.env import require_env
-from lsst.dax.ppdbx.gcp.log_config import setup_logging
 
 # Configure cloud logging
-setup_logging()
+client = cloud_logging.Client()
+client.setup_logging()  # Redirects standard logging to Cloud Logging
+log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
+logging.getLogger().setLevel(log_level)
 
 # Read required environment variables
-PROJECT_ID = require_env("PROJECT_ID")
-DATAFLOW_TEMPLATE_PATH = require_env("DATAFLOW_TEMPLATE_PATH")
-REGION = require_env("REGION")
-SERVICE_ACCOUNT_EMAIL = require_env("SERVICE_ACCOUNT_EMAIL")
-TEMP_LOCATION = require_env("TEMP_LOCATION")
-TOPIC_NAME = require_env("TOPIC_NAME")
+PROJECT_ID = os.environ["PROJECT_ID"]
+DATAFLOW_TEMPLATE_PATH = os.environ["DATAFLOW_TEMPLATE_PATH"]
+REGION = os.environ["REGION"]
+SERVICE_ACCOUNT_EMAIL = os.environ["SERVICE_ACCOUNT_EMAIL"]
+TEMP_LOCATION = os.environ["TEMP_LOCATION"]
+TOPIC_NAME = os.environ["TOPIC_NAME"]
 
 _credentials, _ = google.auth.default()
 _dataflow_client = build("dataflow", "v1b3", credentials=_credentials)

--- a/stage_chunk/main.py
+++ b/stage_chunk/main.py
@@ -64,16 +64,56 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
     context : `google.cloud.functions.Context`
         Metadata of triggering event including `event_id`.
     """
+    # Fields attached to every structured log entry for this invocation.
+    log_fields: dict[str, Any] = {"event_id": getattr(context, "event_id", None)}
+
+    def log_event(
+        level: int,
+        message: str,
+        event_name: str,
+        *,
+        exc_info: bool = False,
+        **fields: Any,
+    ) -> None:
+        """Emit a structured log entry under Cloud Logging ``json_fields``."""
+        logging.log(
+            level,
+            message,
+            exc_info=exc_info,
+            extra={"json_fields": {"event": event_name, **log_fields, **fields}},
+        )
+
     try:
         message = base64.b64decode(event["data"]).decode("utf-8")
     except Exception:
-        logging.exception("Malformed or missing Pub/Sub data payload")
+        log_event(
+            logging.WARNING,
+            "Malformed or missing Pub/Sub data payload",
+            "malformed_pubsub_payload",
+            exc_info=True,
+            pubsub_event=event,
+        )
         return
 
     try:
         data = json.loads(message)
     except json.JSONDecodeError:
-        logging.exception("Failed to decode JSON from Pub/Sub message")
+        log_event(
+            logging.WARNING,
+            "Failed to decode JSON from Pub/Sub message",
+            "json_decode_error",
+            exc_info=True,
+            pubsub_message=message,
+        )
+        return
+
+    if not isinstance(data, dict):
+        log_event(
+            logging.WARNING,
+            "Pub/Sub message is not a JSON object",
+            "invalid_payload_type",
+            pubsub_message=data,
+        )
         return
 
     try:
@@ -81,8 +121,27 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
         chunk_id = data["chunk_id"]
         folder = data["folder"]
     except KeyError:
-        logging.exception("Missing required key in Pub/Sub message")
+        log_event(
+            logging.WARNING,
+            "Missing required key in Pub/Sub message",
+            "missing_key_in_pubsub_message",
+            exc_info=True,
+            missing_keys=[
+                key for key in ["dataset", "chunk_id", "folder"] if key not in data
+            ],
+            pubsub_message=data,
+        )
         return
+
+    # Attach the correlation identifiers to all subsequent logs.
+    log_fields.update(chunk_id=chunk_id, dataset=dataset_id)
+
+    log_event(
+        logging.INFO,
+        "Received stage chunk request",
+        "stage_chunk_request_received",
+        gcs_folder=folder,
+    )
 
     timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
     job_name = f"stage-chunk-{chunk_id}-{timestamp}"
@@ -104,7 +163,13 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
         }
     }
 
-    logging.info("Launching Dataflow job %s to stage chunk %s", job_name, chunk_id)
+    log_event(
+        logging.INFO,
+        "Launching Dataflow job",
+        "dataflow_job_launching",
+        dataflow_job_name=job_name,
+        launch_parameters=launch_body["launchParameter"]["parameters"],
+    )
 
     try:
         request = (
@@ -116,26 +181,58 @@ def trigger_stage_chunk(event: dict[str, Any], context: Context) -> None:
         response = request.execute()
 
         if "job" not in response:
-            logging.error("Dataflow API response missing 'job' field: %s", response)
+            log_event(
+                logging.ERROR,
+                "Dataflow API response missing 'job' field",
+                "dataflow_response_missing_job",
+                dataflow_response=response,
+            )
             return
 
         job_id = response.get("job", {}).get("id", "unknown")
-        logging.info(f"Dataflow job launched: {job_id}")
 
+        log_event(
+            logging.INFO,
+            "Dataflow job launched successfully",
+            "dataflow_job_launched",
+            dataflow_job_id=job_id,
+            dataflow_job_name=job_name,
+        )
     except HttpError as e:
-        if e.resp.status in [429, 500, 503]:
-            logging.warning("Retryable HTTP error (%s): %s", e.resp.status, e)
+        retryable = e.resp.status in (429, 500, 503)
+        log_event(
+            logging.WARNING if retryable else logging.ERROR,
+            "Retryable HTTP error" if retryable else "Non-retryable HTTP error",
+            "retryable_http_error" if retryable else "non_retryable_http_error",
+            exc_info=True,
+            http_status=e.resp.status,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        if retryable:
             raise  # Will trigger retry
-        else:
-            logging.error("Non-retryable HTTP error: %s", e)
-            return  # Acknowledge message
+        return  # Acknowledge message
 
-    except GoogleAPICallError:
-        logging.exception("Retryable GCP API error")
+    except GoogleAPICallError as e:
+        log_event(
+            logging.WARNING,
+            "Retryable GCP API error",
+            "gcp_api_error",
+            exc_info=True,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
         raise  # Will trigger retry
 
-    except Exception:
-        logging.exception("Unexpected error during job submission")
+    except Exception as e:
+        log_event(
+            logging.ERROR,
+            "Unexpected error during job submission",
+            "unexpected_error",
+            exc_info=True,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
         return  # Acknowledge message
 
     return

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -2,7 +2,5 @@ google-auth
 google-api-core
 google-api-python-client
 google-cloud-functions
-google-cloud-storage
-google-cloud-pubsub
 
 lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@main

--- a/stage_chunk/requirements.txt
+++ b/stage_chunk/requirements.txt
@@ -5,4 +5,4 @@ google-cloud-functions
 google-cloud-storage
 google-cloud-pubsub
 
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@main
+lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@main

--- a/stage_chunk/stage_chunk_beam_job.py
+++ b/stage_chunk/stage_chunk_beam_job.py
@@ -293,11 +293,7 @@ def run(argv: Optional[list[str]] = None) -> None:
         for file_name in parquet_files:
             data = read_parquet(pipeline, folder, file_name)
 
-            # TODO: This table name will be changed by DM-54681 to use the
-            # staging dataset with the same table name as the source, e.g.,
-            # 'DiaObject'. For now, we use the conventional staging table name
-            # in the single dataset.
-            table_fqn = f"{project_id}:{dataset_id}._{Path(file_name).stem}_staging"
+            table_fqn = f"{project_id}:{dataset_id}.{Path(file_name).stem}"
 
             write_to_bigquery(
                 data,

--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -63,17 +63,17 @@ def track_chunk(event: dict[str, Any], context: Any) -> None:
             },
         )
 
-        operation = data.get("operation", None)
+        operation = data.get("operation")
         if not operation:
             raise ValueError("Empty 'operation' value in Pub/Sub message")
         if operation != "update":
             raise ValueError(f"Unsupported operation: {operation}")
 
-        values = data.get("values", None)
+        values = data.get("values")
         if not values:
             raise ValueError("No 'values' key found in Pub/Sub message")
 
-        chunk_id = data.get("apdb_replica_chunk", None)
+        chunk_id = data.get("apdb_replica_chunk")
         if not chunk_id:
             raise ValueError("No 'apdb_replica_chunk' value in Pub/Sub message")
 
@@ -84,7 +84,7 @@ def track_chunk(event: dict[str, Any], context: Any) -> None:
         if not chunk:
             raise LookupError(f"Replica chunk {chunk_id} not found")
 
-        new_status = values.get("status", None)
+        new_status = values.get("status")
         if not new_status:
             raise ValueError("Empty 'status' value in values for update operation")
 
@@ -92,6 +92,7 @@ def track_chunk(event: dict[str, Any], context: Any) -> None:
             [chunk.with_new_status(ChunkStatus(new_status))], {"status"}
         )
         if update_count < 1:
+            # This should not happen but raise an error just in case.
             raise LookupError(
                 f"Failed to update replica chunk {chunk_id} with values: {values}"
             )

--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -23,13 +23,22 @@ import base64
 import binascii
 import json
 import logging
+import os
 from typing import Any
 
-from lsst.dax.ppdb.bigquery import PpdbBigQuery
-from lsst.dax.ppdbx.gcp.log_config import setup_logging
+from google.cloud import logging as cloud_logging
+from lsst.dax.ppdb.bigquery import (
+    ChunkStatus,
+    PpdbBigQuery,
+)
 
-# Configure cloud logging
-setup_logging()
+# Configure cloud logging.
+client = cloud_logging.Client()
+client.setup_logging()  # Redirects standard logging to Cloud Logging
+log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
+logging.getLogger().setLevel(log_level)
+
 
 # Setup PPDB BigQuery interface from environment variable configuration
 ppdb = PpdbBigQuery.from_env()
@@ -47,41 +56,57 @@ def track_chunk(event: dict[str, Any], context: Any) -> None:
         except json.JSONDecodeError as e:
             raise Exception("Failed to decode JSON from Pub/Sub message") from e
 
-        logging.info("Received Pub/Sub message: %s", data)
+        logging.info(
+            "Received event to track replica chunk",
+            extra={
+                "json_fields": {"event": "track_chunks_event_received", "data": data}
+            },
+        )
 
-        operation = data.get("operation")
+        operation = data.get("operation", None)
         if not operation:
-            raise KeyError("Missing 'operation' key in Pub/Sub message")
-        # if operation not in ["insert", "update"]:
-        if operation not in ["update"]:
+            raise ValueError("Empty 'operation' value in Pub/Sub message")
+        if operation != "update":
             raise ValueError(f"Unsupported operation: {operation}")
 
-        values = data.get("values")
+        values = data.get("values", None)
         if not values:
             raise ValueError("No 'values' key found in Pub/Sub message")
 
-        if "apdb_replica_chunk" not in data:
-            raise KeyError("Missing 'apdb_replica_chunk' in message")
+        chunk_id = data.get("apdb_replica_chunk", None)
+        if not chunk_id:
+            raise ValueError("No 'apdb_replica_chunk' value in Pub/Sub message")
 
-        chunk_id = data["apdb_replica_chunk"]
+        if operation != "update":
+            raise ValueError(f"Unsupported operation: {operation}")
 
-        if operation == "update":
-            update_count = ppdb.update(chunk_id, values)
-            if update_count == 0:
-                logging.warning(
-                    "No rows updated for replica chunk %d with values: %s",
-                    chunk_id,
-                    values,
-                )
-            else:
-                logging.info(
-                    "Updated replica chunk %d with values: %s (affected rows: %d)",
-                    chunk_id,
-                    values,
-                    update_count,
-                )
-        # elif operation == "insert":
-        #    db.insert(chunk_id, values)
+        chunk = ppdb.find_chunk_by_id(int(chunk_id))
+        if not chunk:
+            raise LookupError(f"Replica chunk {chunk_id} not found")
+
+        new_status = values.get("status", None)
+        if not new_status:
+            raise ValueError("Empty 'status' value in values for update operation")
+
+        update_count = ppdb.update_chunks(
+            [chunk.with_new_status(ChunkStatus(new_status))], {"status"}
+        )
+        if update_count < 1:
+            raise LookupError(
+                f"Failed to update replica chunk {chunk_id} with values: {values}"
+            )
+
+        logging.info(
+            "Updated replica chunk status",
+            extra={
+                "json_fields": {
+                    "event": "replica_chunk_status_updated",
+                    "chunk_id": chunk_id,
+                    "values": values,
+                    "affected_rows": update_count,
+                }
+            },
+        )
 
     except Exception:
-        logging.exception("Error processing Pub/Sub message")
+        logging.exception("Error processing Pub/Sub event")

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,2 +1,1 @@
-lsst-dax-ppdbx-gcp @ git+https://github.com/lsst-dm/dax_ppdbx_gcp@main
-lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@tickets/DM-54070
+lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@main


### PR DESCRIPTION
This is a set of miscellaneous updates and fixes to the cloud functions for supporting the new approach of using multiple datasets. Some of these changes, notably to the `track_chunks` cloud function, should have been applied as part of DM-55016. API changes made there were not propagated properly to that function, and this has been resolved. There are also some general improvements incorporated here, mainly to the logging output.

**Major Changes**

- Changed Dataflow job to use the natural table names in the staging dataset
- Updated the `track_chunk` function to reflect API changes in `lsst/dax_ppdb`
- Removed dependency on `dax_ppdbx_gcp`
  - For now, setup code for logging was duplicated in each function. This setup and other shared utilities will eventually be encapsulated with shared modules in this repository (or in `lsst/dax_ppdb`, if appropriate)
- Updated logging for all functions to use the recommended payload-style with `extra` and `json_fields`
  - This style is much friendlier for cloud logging, as it makes the log messages searchable on the structured JSON payload (`json_fields`) from the web console. Messages are also easier to read without inline parameters, which are instead shown in the (collapsible) details section.

**Minor Changes**

- Increased chunk promotion function memory to `16Gi`
- Turned off `cache_discovery` flag when instantiating Dataflow client to silence noisy warning in log output
- Set logging level of `google_auth_httplib2` to `ERROR` to silence noisy warning in log output
- Removed several unnecessary requirements from `stage_chunk` function