### PR TITLE
DM-55338: Update cloud functions for staging of update records

### DIFF
--- a/promote_chunks/deploy-function.sh
+++ b/promote_chunks/deploy-function.sh
@@ -17,4 +17,4 @@ gcloud functions deploy promote-chunks \
   --service-account="${SERVICE_ACCOUNT_EMAIL}" \
   --memory=16Gi \
   --timeout=900s \
-  --set-env-vars "PPDB_CONFIG_URI=${PPDB_CONFIG_URI},PPDB_USE_SECRET_MANAGER=true"
+  --set-env-vars "PPDB_CONFIG_URI=${PPDB_CONFIG_URI},PPDB_USE_SECRET_MANAGER=true,LOG_LEVEL=${LOG_LEVEL}"

--- a/promote_chunks/main.py
+++ b/promote_chunks/main.py
@@ -22,17 +22,23 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import os
 
 from flask import Request, jsonify
+from google.cloud import logging as cloud_logging
 from lsst.dax.ppdb.bigquery import PpdbBigQuery
 from lsst.dax.ppdb.bigquery.chunk_promoter import (
     ChunkPromoter,
     NoPromotableChunksError,
 )
-from lsst.dax.ppdbx.gcp.log_config import setup_logging
 
-# Configure cloud logging
-setup_logging()
+# Configure cloud logging.
+client = cloud_logging.Client()
+client.setup_logging()  # Redirects standard logging to Cloud Logging
+log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
+logging.getLogger().setLevel(log_level)
+
 
 # Setup PPDB BigQuery interface from environment variable configuration
 ppdb = PpdbBigQuery.from_env()

--- a/stage_chunk/stage_chunk_beam_job.py
+++ b/stage_chunk/stage_chunk_beam_job.py
@@ -39,7 +39,6 @@ from apache_beam.options.pipeline_options import (
 from google.cloud import logging as cloud_logging
 from google.cloud import pubsub_v1, storage
 from lsst.dax.ppdb.bigquery import Manifest
-from lsst.dax.ppdb.bigquery.updates import UpdateRecords
 
 # Configure Google Cloud logging
 cloud_logging.Client().setup_logging()
@@ -281,16 +280,8 @@ def run(argv: Optional[list[str]] = None) -> None:
 
     logging.info("Loading table files: %s", list(manifest.files))
 
-    # Filter out the update records file from the list of parquet files to be
-    # staged.
-    parquet_files = [
-        name
-        for name in manifest.files.keys()
-        if name != UpdateRecords.PARQUET_FILE_NAME
-    ]
-
     with apache_beam.Pipeline(options=options) as pipeline:
-        for file_name in parquet_files:
+        for file_name in manifest.files:
             data = read_parquet(pipeline, folder, file_name)
 
             table_fqn = f"{project_id}:{dataset_id}.{Path(file_name).stem}"

--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -27,10 +27,7 @@ import os
 from typing import Any
 
 from google.cloud import logging as cloud_logging
-from lsst.dax.ppdb.bigquery import (
-    ChunkStatus,
-    PpdbBigQuery,
-)
+from lsst.dax.ppdb.bigquery import ChunkStatus, PpdbBigQuery, UpdatableField
 
 # Configure cloud logging.
 client = cloud_logging.Client()
@@ -89,7 +86,7 @@ def track_chunk(event: dict[str, Any], context: Any) -> None:
             raise ValueError("Empty 'status' value in values for update operation")
 
         update_count = ppdb.update_chunks(
-            [chunk.with_new_status(ChunkStatus(new_status))], {"status"}
+            [chunk.with_new_status(ChunkStatus(new_status))], {UpdatableField.STATUS}
         )
         if update_count < 1:
             # This should not happen but raise an error just in case.


### PR DESCRIPTION
This changes the staging of update records so they are handled like the procedure for regular table data: https://github.com/lsst-dm/ppdb-cloud-functions/pull/14/commits/ee29c772f8120e1c4c75ab236147bc8a9f388b13

There are also some minor updates to the logging, as well as an update to how the updatable fields are handled using an enum.