### PR TITLE
DM-55731: Dataflow GHA

### DIFF
--- a/.github/workflows/dataflow-build-flex-deploy-dev.yaml
+++ b/.github/workflows/dataflow-build-flex-deploy-dev.yaml
@@ -1,0 +1,68 @@
+name: Dataflow Push to Artifact Registry and Flex Template Upload Dev
+
+on:
+  pull_request:
+    paths:
+      - 'stage_chunk/Dockerfile'
+      - 'stage_chunk/stage_chunk_beam_job.py'
+      - 'stage_chunk/requirements-dataflow.txt'
+  push:
+    branches:
+      - main
+    paths:
+      - 'stage_chunk/Dockerfile'
+      - 'stage_chunk/stage_chunk_beam_job.py'
+      - 'stage_chunk/requirements-dataflow.txt'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./stage_chunk
+
+    env:
+      PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
+      ENVIRONMENT: dev
+      GAR_LOCATION: ${{ vars.GCP_DEV_REGION }}
+      REPOSITORY: ppdb-repo
+      IMAGE: stage-chunk-image
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
+
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_CREDENTIALS_DEV }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v7
+        with:
+          context: "{{defaultContext}}:stage_chunk"
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and Push Dataflow Flex Template
+        run: |
+          gcloud dataflow flex-template build "gs://ppdb-${{ env.ENVIRONMENT }}-dataflow/templates/stage_chunk_flex_template.json" \
+            --image "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}" \
+            --sdk-language "PYTHON" \
+            --metadata-file "metadata.json"

--- a/.github/workflows/stage-chunk-deploy-dev.yaml
+++ b/.github/workflows/stage-chunk-deploy-dev.yaml
@@ -3,7 +3,7 @@ name: Stage Chunk Cloud Run Deploy Dev
 on:
   pull_request:
     paths:
-      - 'stage_chunk/*.py'
+      - 'stage_chunk/main.py'
       - 'stage_chunk/requirements.txt'
   push:
     branches:


### PR DESCRIPTION
Introduces a new GitHub Actions workflow for automating the build and deployment process of the Dataflow Flex Template to the dev environment. The workflow handles authentication, Docker image building and pushing, and Dataflow template creation.

* Added `.github/workflows/dataflow-build-flex-deploy-dev.yaml` workflow to automatically build and push the Docker image for the `stage_chunk` job to Google Artifact Registry and build the Dataflow Flex Template on pull requests and pushes to `main`.
* Configured GCP authentication using a service account key, and set up Docker and Buildx for image builds and caching.
* Automated the creation and upload of the Dataflow Flex Template to the appropriate GCS bucket
* Commit SHAs are used as tags for the container build and flex template to avoid potential issues with image caching
* Filters out dataflow files from trigger stage chunk cloud run to avoid triggering cloud run deploys