### PR TITLE
DM-55936: Add ability to trigger dev deploys manually

### DIFF
--- a/.github/workflows/dataflow-build-flex-deploy-dev.yaml
+++ b/.github/workflows/dataflow-build-flex-deploy-dev.yaml
@@ -13,6 +13,7 @@ on:
       - 'stage_chunk/Dockerfile'
       - 'stage_chunk/stage_chunk_beam_job.py'
       - 'stage_chunk/requirements-dataflow.txt'
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/.github/workflows/dataflow-build-flex-deploy-dev.yaml
+++ b/.github/workflows/dataflow-build-flex-deploy-dev.yaml
@@ -18,6 +18,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: dev/stage-chunk-dataflow
+
     defaults:
       run:
         shell: bash

--- a/.github/workflows/promote-chunks-deploy-dev.yaml
+++ b/.github/workflows/promote-chunks-deploy-dev.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: dev/promote-chunks
 
     env:
       PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}

--- a/.github/workflows/promote-chunks-deploy-dev.yaml
+++ b/.github/workflows/promote-chunks-deploy-dev.yaml
@@ -13,6 +13,7 @@ on:
       - 'promote_chunks/main.py'
       - 'promote_chunks/requirements.txt'
       - 'promote_chunks/Dockerfile'
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -28,44 +29,44 @@ jobs:
       APP_SOURCE_PATH: promote_chunks
       RUNTIME: 'python313'
       ENTRY_POINT: 'promote_chunks'
-      CPU: ${{ vars.PROMOTE_CHUNKS_CPU }} 
+      CPU: ${{ vars.PROMOTE_CHUNKS_CPU }}
       MEMORY: ${{ vars.PROMOTE_CHUNKS_MEMORY }}
       TIMEOUT: ${{ vars.PROMOTE_CHUNKS_TIMEOUT }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v3'
-      with:
-        credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
 
-    - name: Log in to Google Artifact Registry
-      uses: docker/login-action@v4
-      with:
-        registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
-        username: _json_key
-        password: ${{ secrets.GCP_CREDENTIALS_DEV }}
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_CREDENTIALS_DEV }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-    - name: Build and Push Docker Image
-      uses: docker/build-push-action@v7
-      with:
-        context: "{{defaultContext}}:promote_chunks"
-        file: ./Dockerfile
-        push: true
-        tags: |
-          ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v7
+        with:
+          context: "{{defaultContext}}:promote_chunks"
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-    - name: Deploy to Cloud Run Job
-      uses: google-github-actions/deploy-cloudrun@v3
-      with:
-        job: ${{ env.JOB_NAME }}
-        image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
-        region: ${{ env.REGION }}
+      - name: Deploy to Cloud Run Job
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          job: ${{ env.JOB_NAME }}
+          image: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
+          region: ${{ env.REGION }}

--- a/.github/workflows/stage-chunk-deploy-dev.yaml
+++ b/.github/workflows/stage-chunk-deploy-dev.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'stage_chunk/*.py'
       - 'stage_chunk/requirements.txt'
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -27,25 +28,24 @@ jobs:
       MEMORY: ${{ vars.TRIGGER_STAGE_CHUNK_MEMORY }}
       TIMEOUT: ${{ vars.TRIGGER_STAGE_CHUNK_TIMEOUT }}
 
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v3'
-      with:
-        credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
 
-    - name: 'Deploy to Cloud Run Functions'
-      uses: 'google-github-actions/deploy-cloud-functions@v4'
-      with:
-        name: ${{ env.SERVICE_NAME }}
-        region: ${{ env.REGION }}
-        source_dir: ${{ env.APP_SOURCE_PATH }}
-        runtime: ${{ env.RUNTIME }}
-        entry_point: ${{ env.ENTRY_POINT }}
-        cpu: ${{ env.CPU }}
-        memory: ${{ env.MEMORY }}
-        service_timeout: ${{ env.TIMEOUT }}
+      - name: 'Deploy to Cloud Run Functions'
+        uses: 'google-github-actions/deploy-cloud-functions@v4'
+        with:
+          name: ${{ env.SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          source_dir: ${{ env.APP_SOURCE_PATH }}
+          runtime: ${{ env.RUNTIME }}
+          entry_point: ${{ env.ENTRY_POINT }}
+          cpu: ${{ env.CPU }}
+          memory: ${{ env.MEMORY }}
+          service_timeout: ${{ env.TIMEOUT }}

--- a/.github/workflows/stage-chunk-deploy-dev.yaml
+++ b/.github/workflows/stage-chunk-deploy-dev.yaml
@@ -16,6 +16,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: dev/stage-chunk
 
     env:
       PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}

--- a/.github/workflows/track-chunk-deploy-dev.yaml
+++ b/.github/workflows/track-chunk-deploy-dev.yaml
@@ -16,6 +16,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: dev/track-chunk
 
     env:
       PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}

--- a/.github/workflows/track-chunk-deploy-dev.yaml
+++ b/.github/workflows/track-chunk-deploy-dev.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'track_chunk/*.py'
       - 'track_chunk/requirements.txt'
+    workflow_dispatch:
 
 jobs:
   deploy:
@@ -28,23 +29,23 @@ jobs:
       TIMEOUT: ${{ vars.TRACK_CHUNK_TIMEOUT }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v3'
-      with:
-        credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
 
-    - name: 'Deploy to Cloud Run Functions'
-      uses: 'google-github-actions/deploy-cloud-functions@v4'
-      with:
-        name: ${{ env.SERVICE_NAME }}
-        region: ${{ env.REGION }}
-        source_dir: ${{ env.APP_SOURCE_PATH }}
-        runtime: ${{ env.RUNTIME }}
-        entry_point: ${{ env.ENTRY_POINT }}
-        cpu: ${{ env.CPU }}
-        memory: ${{ env.MEMORY }}
-        service_timeout: ${{ env.TIMEOUT }}
+      - name: 'Deploy to Cloud Run Functions'
+        uses: 'google-github-actions/deploy-cloud-functions@v4'
+        with:
+          name: ${{ env.SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          source_dir: ${{ env.APP_SOURCE_PATH }}
+          runtime: ${{ env.RUNTIME }}
+          entry_point: ${{ env.ENTRY_POINT }}
+          cpu: ${{ env.CPU }}
+          memory: ${{ env.MEMORY }}
+          service_timeout: ${{ env.TIMEOUT }}


### PR DESCRIPTION
This would be nice, at least while we’re developing this system, so that we can test the workflows without having to make no-op commits to the function code.

@JeremyMcCormick if you don't like the GitHub env stuff we can rip it out very easily and pretend it never happened.