### PR TITLE
DM-55678: Add Cloud Run function for loading SSO table data into BigQuery using Dataflow

### DIFF
--- a/.github/workflows/load-sso-build-flex-deploy-dev.yaml
+++ b/.github/workflows/load-sso-build-flex-deploy-dev.yaml
@@ -1,0 +1,72 @@
+name: Dev - Load SSO Dataflow Push to Artifact Registry and Flex Template Upload
+
+# TODO: Automatic triggers are disabled for now; use workflow_dispatch until
+# this workflow is ready to run automatically.
+on:
+  # pull_request:
+  #   paths:
+  #     - 'load_sso/Dockerfile'
+  #     - 'load_sso/load_sso_beam_job.py'
+  #     - 'load_sso/requirements-dataflow.txt'
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'load_sso/Dockerfile'
+  #     - 'load_sso/load_sso_beam_job.py'
+  #     - 'load_sso/requirements-dataflow.txt'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: dev/load-sso-dataflow
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./load_sso
+
+    env:
+      PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
+      ENVIRONMENT: dev
+      GAR_LOCATION: ${{ vars.GCP_DEV_REGION }}
+      REPOSITORY: ppdb-repo
+      IMAGE: load-sso-image
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
+
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_CREDENTIALS_DEV }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v7
+        with:
+          context: "{{defaultContext}}:load_sso"
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and Push Dataflow Flex Template
+        run: |
+          gcloud dataflow flex-template build "gs://ppdb-${{ env.ENVIRONMENT }}-dataflow/templates/load_sso_flex_template.json" \
+            --image "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE }}:${{ github.sha }}" \
+            --sdk-language "PYTHON" \
+            --metadata-file "metadata.json"

--- a/.github/workflows/load-sso-deploy-dev.yaml
+++ b/.github/workflows/load-sso-deploy-dev.yaml
@@ -1,0 +1,55 @@
+name: Dev - Load SSO Cloud Run Deploy
+
+# TODO: Automatic triggers are disabled for now; use workflow_dispatch until
+# this workflow is ready to run automatically.
+on:
+  # pull_request:
+  #   paths:
+  #     - 'load_sso/main.py'
+  #     - 'load_sso/requirements.txt'
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'load_sso/*.py'
+  #     - 'load_sso/requirements.txt'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev/load-sso
+
+    env:
+      PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
+      REGION: ${{ vars.GCP_DEV_REGION }}
+      SERVICE_NAME: load-sso
+      APP_SOURCE_PATH: load_sso
+      RUNTIME: 'python313'
+      ENTRY_POINT: 'load_sso'
+      CPU: ${{ vars.LOAD_SSO_CPU }}
+      MEMORY: ${{ vars.LOAD_SSO_MEMORY }}
+      TIMEOUT: ${{ vars.LOAD_SSO_TIMEOUT }}
+
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v3'
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS_DEV }}
+
+    - name: 'Deploy to Cloud Run Functions'
+      uses: 'google-github-actions/deploy-cloud-functions@v4'
+      with:
+        name: ${{ env.SERVICE_NAME }}
+        region: ${{ env.REGION }}
+        source_dir: ${{ env.APP_SOURCE_PATH }}
+        runtime: ${{ env.RUNTIME }}
+        entry_point: ${{ env.ENTRY_POINT }}
+        cpu: ${{ env.CPU }}
+        memory: ${{ env.MEMORY }}
+        service_timeout: ${{ env.TIMEOUT }}

--- a/load_sso/Dockerfile
+++ b/load_sso/Dockerfile
@@ -1,0 +1,16 @@
+# Use the official Python image as the base image (Python 3.13).
+FROM gcr.io/dataflow-templates-base/python313-template-launcher-base:latest
+
+# Copy your pipeline code inside the container.
+WORKDIR /dataflow/template
+COPY load_sso_beam_job.py .
+
+# Install the required dependencies.
+COPY requirements-dataflow.txt .
+RUN pip install --no-cache-dir -r requirements-dataflow.txt
+
+# Set required environment variable for Flex Templates.
+ENV FLEX_TEMPLATE_PYTHON_PY_FILE=load_sso_beam_job.py
+
+# Use the standard launcher ENTRYPOINT.
+ENTRYPOINT ["/opt/apache/beam/boot"]

--- a/load_sso/load_sso_beam_job.py
+++ b/load_sso/load_sso_beam_job.py
@@ -1,0 +1,218 @@
+# This file is part of ppdb-cloud-functions.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+import logging
+import posixpath
+from typing import Any
+
+import apache_beam
+from apache_beam import PCollection
+from apache_beam.io.gcp.bigquery import BigQueryDisposition, WriteToBigQuery
+from apache_beam.io.parquetio import ReadFromParquet
+from apache_beam.options.pipeline_options import (
+    GoogleCloudOptions,
+    PipelineOptions,
+    SetupOptions,
+)
+from google.cloud import logging as cloud_logging
+
+# Configure Google Cloud logging
+cloud_logging.Client().setup_logging()
+logging.getLogger().setLevel(logging.INFO)
+_LOG = logging.getLogger(__name__)
+
+
+class BeamSuppressUpdateDestinationSchemaWarning(logging.Filter):
+    """Suppresses the UpdateDestinationSchema warning from Apache Beam."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Suppress the UpdateDestinationSchema warning.
+
+        Parameters
+        ----------
+        record : `logging.LogRecord`
+            The log record to filter.
+        """
+        if record.name == "apache_beam.transforms.core":
+            message = str(record.getMessage())
+            if "No iterator is returned by the process method" in message:
+                return False
+        return True
+
+
+logging.getLogger("apache_beam.transforms.core").addFilter(
+    BeamSuppressUpdateDestinationSchemaWarning()
+)
+
+
+def log_event(level: int, message: str, event_name: str, **fields: Any) -> None:
+    """Emit a structured log entry under Cloud Logging ``json_fields``."""
+    _LOG.log(level, message, extra={"json_fields": {"event": event_name, **fields}})
+
+
+class CustomOptions(PipelineOptions):
+    """Custom options for the pipeline."""
+
+    @classmethod
+    def _add_argparse_args(cls, parser: argparse.ArgumentParser) -> None:
+        """Add custom arguments to the parser.
+
+        Parameters
+        ----------
+        parser : `argparse.ArgumentParser`
+            The argument parser to add arguments to.
+        """
+        parser.add_argument("--dataset_id", required=True, help="BigQuery dataset ID")
+        parser.add_argument(
+            "--bucket",
+            required=True,
+            help="GCS bucket containing the SSO Parquet files",
+        )
+        parser.add_argument(
+            "--object_prefix",
+            required=True,
+            help="GCS object prefix containing the SSO Parquet files",
+        )
+        parser.add_argument(
+            "--tables",
+            required=True,
+            help="Comma-separated list of SSO table names to load",
+        )
+
+
+def read_parquet(
+    pipeline: apache_beam.Pipeline, bucket: str, object_prefix: str, table_name: str
+) -> PCollection:
+    """Read a Parquet file from GCS.
+
+    Parameters
+    ----------
+    pipeline : `apache_beam.Pipeline`
+        The Apache Beam pipeline.
+    bucket : `str`
+        The GCS bucket containing the Parquet file.
+    object_prefix : `str`
+        The GCS object prefix containing the Parquet file.
+    table_name : `str`
+        The name of the SSO table to read.
+
+    Returns
+    -------
+    transform: `apache_beam.PTransform`
+        The transform to read the Parquet file.
+    """
+    parquet_path = (
+        f"gs://{posixpath.join(bucket, object_prefix, f'{table_name}.parquet')}"
+    )
+    log_event(
+        logging.INFO,
+        "Reading Parquet file",
+        "reading_parquet_file",
+        table_name=table_name,
+        parquet_path=parquet_path,
+    )
+    return pipeline | f"Read{table_name}" >> ReadFromParquet(parquet_path)
+
+
+def write_to_bigquery(
+    pcoll: apache_beam.PCollection,
+    table_fqn: str,
+    temp_location: str,
+) -> PCollection:
+    """Write PCollection to BigQuery.
+
+    Parameters
+    ----------
+    pcoll : `apache_beam.PCollection`
+        The PCollection to write to BigQuery.
+    table_fqn : `str`
+        The fully qualified name of the BigQuery table in the format `project_id:dataset_id.table_name`.
+    temp_location : `str`
+        The GCS path for temporary files.
+
+    Returns
+    -------
+    transform: `apache_beam.PTransform`
+        The transform to write the PCollection to BigQuery.
+    """
+    log_event(
+        logging.INFO,
+        "Writing to BigQuery table",
+        "writing_to_bigquery",
+        table_fqn=table_fqn,
+    )
+    # SSO tables are fully replaced on every run, not incrementally appended.
+    return pcoll | f"Write{table_fqn}" >> WriteToBigQuery(
+        table=table_fqn,
+        create_disposition=BigQueryDisposition.CREATE_NEVER,
+        write_disposition=BigQueryDisposition.WRITE_TRUNCATE,
+        custom_gcs_temp_location=temp_location,
+    )
+
+
+def run(argv: list[str] | None = None) -> None:
+    """Run the pipeline."""
+    options = PipelineOptions(argv)
+    custom_options = options.view_as(CustomOptions)
+
+    gcp_options = options.view_as(GoogleCloudOptions)
+    options.view_as(SetupOptions).save_main_session = True
+
+    temp_location = gcp_options.temp_location
+    if not temp_location:
+        raise ValueError("GCP temp_location must be set in pipeline options.")
+
+    dataset_id = custom_options.dataset_id
+    bucket = custom_options.bucket
+    object_prefix = custom_options.object_prefix
+    tables = custom_options.tables.split(",")
+
+    log_event(
+        logging.INFO,
+        "Loading SSO tables",
+        "load_sso_tables_started",
+        tables=tables,
+        bucket=bucket,
+        object_prefix=object_prefix,
+        dataset_id=dataset_id,
+    )
+
+    if ":" in dataset_id:
+        project_id, dataset_id = dataset_id.split(":", 1)
+    else:
+        project_id = gcp_options.project
+
+    with apache_beam.Pipeline(options=options) as pipeline:
+        for table_name in tables:
+            data = read_parquet(pipeline, bucket, object_prefix, table_name)
+
+            table_fqn = f"{project_id}:{dataset_id}.{table_name}"
+
+            write_to_bigquery(
+                data,
+                table_fqn,
+                temp_location,
+            )
+
+
+if __name__ == "__main__":
+    run()

--- a/load_sso/main.py
+++ b/load_sso/main.py
@@ -1,0 +1,255 @@
+# This file is part of ppdb-cloud-functions.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import base64
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import functions_framework
+import google.auth
+from cloudevents.http import CloudEvent
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import logging as cloud_logging
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# Configure cloud logging.
+client = cloud_logging.Client()
+client.setup_logging()  # Redirects standard logging to Cloud Logging
+log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
+logging.getLogger().setLevel(log_level)
+
+# Silence noisy warnings from google-auth-httplib2.
+logging.getLogger("google_auth_httplib2").setLevel(logging.ERROR)
+
+_LOG = logging.getLogger(__name__)
+
+# Read required environment variables.
+PROJECT_ID = os.environ["PROJECT_ID"]
+DATAFLOW_TEMPLATE_PATH = os.environ["DATAFLOW_TEMPLATE_PATH"]
+REGION = os.environ["REGION"]
+SERVICE_ACCOUNT_EMAIL = os.environ["SERVICE_ACCOUNT_EMAIL"]
+TEMP_LOCATION = os.environ["TEMP_LOCATION"]
+GOOGLE_CLOUD_SUBNETWORK = os.environ["GOOGLE_CLOUD_SUBNETWORK"]
+
+_credentials, _ = google.auth.default()
+_dataflow_client = build(
+    "dataflow",
+    "v1b3",
+    credentials=_credentials,
+    cache_discovery=False,
+)
+
+
+@functions_framework.cloud_event
+def load_sso(event: CloudEvent) -> None:
+    """Cloud Function to launch a Dataflow job to load SSO data.
+
+    Parameters
+    ----------
+    cloud_event : `CloudEvent`
+        The CloudEvent delivered by the Pub/Sub trigger. The Pub/Sub message
+        is available at ``cloud_event.data["message"]`` and its ``data`` field
+        contains a base64-encoded string representing a JSON message with
+        ``bucket``, ``object_prefix``, ``uploaded_tables`` and ``dataset_id``
+        fields.
+    """
+    # Fields attached to every structured log entry for this invocation.
+    log_fields: dict[str, Any] = {"event_id": event["id"]}
+
+    def log_event(
+        level: int,
+        message: str,
+        event_name: str,
+        *,
+        exc_info: bool = False,
+        **fields: Any,
+    ) -> None:
+        """Emit a structured log entry under Cloud Logging ``json_fields``."""
+        _LOG.log(
+            level,
+            message,
+            exc_info=exc_info,
+            extra={"json_fields": {"event": event_name, **log_fields, **fields}},
+        )
+
+    def handle_error(e: Exception) -> bool:
+        """Log a job-submission failure and report whether it is retryable."""
+        extra_fields: dict[str, Any] = {}
+        if isinstance(e, HttpError):
+            retryable = e.resp.status in (429, 500, 503)
+            extra_fields["http_status"] = e.resp.status
+        elif isinstance(e, GoogleAPICallError):
+            retryable = True
+        else:
+            retryable = False
+
+        if retryable:
+            level = logging.WARNING
+            log_message = "Retryable error during job submission"
+            event_name = "retryable_error"
+        else:
+            level = logging.ERROR
+            log_message = "Non-retryable error during job submission"
+            event_name = "non_retryable_error"
+
+        log_event(
+            level,
+            log_message,
+            event_name,
+            exc_info=True,
+            error=str(e),
+            error_type=type(e).__name__,
+            **extra_fields,
+        )
+        return retryable
+
+    try:
+        message = base64.b64decode(event.data["message"]["data"]).decode("utf-8")
+    except Exception:
+        log_event(
+            logging.WARNING,
+            "Malformed or missing Pub/Sub data payload",
+            "malformed_pubsub_payload",
+            exc_info=True,
+            pubsub_event=event.data,
+        )
+        return
+
+    try:
+        data = json.loads(message)
+    except json.JSONDecodeError:
+        log_event(
+            logging.WARNING,
+            "Failed to decode JSON from Pub/Sub message",
+            "json_decode_error",
+            exc_info=True,
+            pubsub_message=message,
+        )
+        return
+
+    if not isinstance(data, dict):
+        log_event(
+            logging.WARNING,
+            "Pub/Sub message is not a JSON object",
+            "invalid_payload_type",
+            pubsub_message=data,
+        )
+        return
+
+    try:
+        bucket = data["bucket"]
+        object_prefix = data["object_prefix"]
+        uploaded_tables = data["uploaded_tables"]
+        dataset_id = data["dataset_id"]
+    except KeyError:
+        log_event(
+            logging.WARNING,
+            "Missing required key in Pub/Sub message",
+            "missing_key_in_pubsub_message",
+            exc_info=True,
+            missing_keys=[
+                key
+                for key in ["bucket", "object_prefix", "uploaded_tables", "dataset_id"]
+                if key not in data
+            ],
+            pubsub_message=data,
+        )
+        return
+
+    # Attach the correlation identifiers to all subsequent logs.
+    log_fields.update(dataset=dataset_id)
+
+    log_event(
+        logging.INFO,
+        "Received load SSO request",
+        "load_sso_request_received",
+        gcs_bucket=bucket,
+        gcs_object_prefix=object_prefix,
+        uploaded_tables=uploaded_tables,
+    )
+
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+    job_name = f"load-sso-{timestamp}"
+
+    launch_body = {
+        "launchParameter": {
+            "jobName": job_name,
+            "containerSpecGcsPath": DATAFLOW_TEMPLATE_PATH,
+            "parameters": {
+                "dataset_id": dataset_id,
+                "bucket": bucket,
+                "object_prefix": object_prefix,
+                "tables": ",".join(uploaded_tables),
+            },
+            "environment": {
+                "serviceAccountEmail": SERVICE_ACCOUNT_EMAIL,
+                "tempLocation": TEMP_LOCATION,
+                "subnetwork": GOOGLE_CLOUD_SUBNETWORK,
+            },
+        }
+    }
+
+    log_event(
+        logging.INFO,
+        "Launching Dataflow job",
+        "dataflow_job_launching",
+        dataflow_job_name=job_name,
+        launch_parameters=launch_body["launchParameter"]["parameters"],
+        environment=launch_body["launchParameter"]["environment"],
+        container_spec_gcs_path=launch_body["launchParameter"]["containerSpecGcsPath"],
+    )
+
+    try:
+        request = (
+            _dataflow_client.projects()
+            .locations()
+            .flexTemplates()
+            .launch(projectId=PROJECT_ID, location=REGION, body=launch_body)
+        )
+        response = request.execute()
+
+        if "job" not in response:
+            log_event(
+                logging.ERROR,
+                "Dataflow API response missing 'job' field",
+                "dataflow_response_missing_job",
+                dataflow_response=response,
+            )
+            return
+
+        job_id = response.get("job", {}).get("id", "unknown")
+
+        log_event(
+            logging.INFO,
+            "Dataflow job launched successfully",
+            "dataflow_job_launched",
+            dataflow_job_id=job_id,
+            dataflow_job_name=job_name,
+        )
+    except Exception as e:
+        if handle_error(e):
+            raise  # Will trigger retry
+        return  # Acknowledge message

--- a/load_sso/metadata.json
+++ b/load_sso/metadata.json
@@ -1,0 +1,34 @@
+{
+    "name": "Load SSO Beam Job",
+    "description": "Loads SSO parquet tables into BigQuery",
+    "parameters": [
+      {
+        "name": "bucket",
+        "label": "GCS bucket",
+        "helpText": "GCS bucket containing the SSO Parquet files",
+        "paramType": "TEXT",
+        "isOptional": false
+      },
+      {
+        "name": "object_prefix",
+        "label": "GCS object prefix",
+        "helpText": "GCS object prefix containing the SSO Parquet files",
+        "paramType": "TEXT",
+        "isOptional": false
+      },
+      {
+        "name": "dataset_id",
+        "label": "BigQuery dataset ID",
+        "helpText": "Target BigQuery dataset",
+        "paramType": "TEXT",
+        "isOptional": false
+      },
+      {
+        "name": "tables",
+        "label": "SSO table names",
+        "helpText": "Comma-separated list of SSO table names to load",
+        "paramType": "TEXT",
+        "isOptional": false
+      }
+    ]
+  }

--- a/load_sso/requirements-dataflow.txt
+++ b/load_sso/requirements-dataflow.txt
@@ -1,0 +1,2 @@
+google-cloud-logging
+google-cloud-storage

--- a/load_sso/requirements.txt
+++ b/load_sso/requirements.txt
@@ -1,0 +1,7 @@
+functions-framework
+google-auth
+google-api-core
+google-api-python-client
+google-cloud-functions
+
+lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@cloudrun-v1.0.0

--- a/load_sso/requirements.txt
+++ b/load_sso/requirements.txt
@@ -4,4 +4,4 @@ google-api-core
 google-api-python-client
 google-cloud-functions
 
-lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@cloudrun-v1.0.0
+lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@tickets/DM-55678


### PR DESCRIPTION
## Summary
- Implemented DM-55678 by adding a new `load-sso` Cloud Run function that consumes Pub/Sub notifications and launches a Dataflow Flex Template job for loading SSO data into BigQuery.
- Added the Beam/Dataflow pipeline, Flex Template metadata, container image definition, and requirements needed to read SSO parquet files from GCS and write them into existing BigQuery tables.
- Added dev GitHub Actions workflows to deploy the Cloud Run function and to build/push the Dataflow image plus upload the Flex Template.
  - Possible that `int` workflows should be included here as well. (?) 

## Notes
- The Pub/Sub payload is expected to include `bucket`, `object_prefix`, `uploaded_tables`, and `dataset_id`.
- The Beam job loads the requested tables with `WRITE_TRUNCATE`, replacing the target BigQuery tables on each run.
  - Existing BQ tables which are not included in the `uploaded_tables` list are left alone and not truncated.
- The new workflows are using `workflow_dispatch` temporarily.
  - This will be changed to match the automatic deployment in other workflows for the final version of this PR.
- Updated the `lsst-dax-ppdb` dependency to use the `tickets/DM-55678` branch.
  - This will be replaced with a tag once those changes are merged into `dax_ppdb` and a release is made.
