### PR TITLE
DM-56004: Update Track Chunks to 2nd gen Cloud Run function

### DIFF
--- a/track_chunk/main.py
+++ b/track_chunk/main.py
@@ -24,8 +24,9 @@ import binascii
 import json
 import logging
 import os
-from typing import Any
 
+import functions_framework
+from cloudevents.http import CloudEvent
 from google.cloud import logging as cloud_logging
 from lsst.dax.ppdb.bigquery import ChunkStatus, PpdbBigQuery, UpdatableField
 
@@ -41,10 +42,11 @@ logging.getLogger().setLevel(log_level)
 ppdb = PpdbBigQuery.from_env()
 
 
-def track_chunk(event: dict[str, Any], context: Any) -> None:
+@functions_framework.cloud_event
+def track_chunk(event: CloudEvent) -> None:
     try:
         try:
-            message = base64.b64decode(event["data"]).decode("utf-8")
+            message = base64.b64decode(event.data["message"]["data"]).decode("utf-8")
         except (KeyError, binascii.Error, UnicodeDecodeError) as e:
             raise Exception("Malformed or missing Pub/Sub data payload") from e
 

--- a/track_chunk/requirements.txt
+++ b/track_chunk/requirements.txt
@@ -1,1 +1,3 @@
+functions-framework
+
 lsst-dax-ppdb @ git+https://github.com/lsst/dax_ppdb@cloudrun-v1.0.0


### PR DESCRIPTION
Cloud Run 2nd gen functions use `CloudEvent` instead of `event` and `context` arguments.